### PR TITLE
feat(git-version): add "get version from git" action

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*/dist/*.js -diff

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ This repository contains custom [Actions][] for Opentrons project running CI/CD 
 
 ## Actions
 
-| action | description               |
-| ------ | ------------------------- |
-| TBD    | Something cool, hopefully |
+| action                   | description                                         |
+| ------------------------ | --------------------------------------------------- |
+| [Get Version From Git][] | Get a version string for a build using git metadata |
+
+[get version from git]: ./git-version
 
 ## Contributing
 

--- a/git-version/README.md
+++ b/git-version/README.md
@@ -1,0 +1,64 @@
+# Get Version From Git Action
+
+This action inspects your repository's git tags and the current commit to generate a version string for the current build.
+
+- If commit matches tag, parse version from tag
+- Otherwise, generate a snapshot version based on most recent tag
+
+## Usage
+
+The algorithm the action uses is similar to `git describe`, except it uses the GitHub API rather than querying `git`. This means that **you don't need to clone your repository's full history** in the checkout step.
+
+```yaml
+# ...
+steps:
+  # ...
+  - name: 'Calculate version string from git'
+    id: version
+    uses: Opentrons/actions/git-version@v1
+    with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      tag-prefix: v # default
+      bump: minor # default
+      snapshot-id: dev # default
+      prerelease-id: alpha # default, unused because `bump` not a prerelease
+
+  - name: 'Print version'
+    run: echo "Version: ${{ steps.version.outputs.version }}"
+# ...
+```
+
+### Inputs
+
+| name            | default | required | description                             | example                       |
+| --------------- | ------- | -------- | --------------------------------------- | ----------------------------- |
+| `github-token`  | N/A     | **yes**  | GitHub access token                     | `${{ secrets.GITHUB_TOKEN }}` |
+| `tag-prefix`    | `v`     | no       | Prefix to filter tags                   | `v`, `project-name@`          |
+| `bump`          | `minor` | no       | Bump to create snapshot version         | `prerelease`, `patch`         |
+| `snapshot-id`   | `dev`   | no       | Label to mark snapshot version          | `dev`, `SNAPSHOT`             |
+| `prerelease-id` | `alpha` | no       | If `bump` is a prerelease, label to use | `alpha`, `canary`             |
+
+### Outputs
+
+| name      | description                      | example                       |
+| --------- | -------------------------------- | ----------------------------- |
+| `version` | Calculated version for the build | `${{ secrets.GITHUB_TOKEN }}` |
+
+### Example versions
+
+| bump       | prerelease ID | snapshot ID | closest tag      | commits ahead | current SHA | output                         |
+| ---------- | ------------- | ----------- | ---------------- | ------------- | ----------- | ------------------------------ |
+| `minor`    | `alpha`       | `dev`       | None found       | N/A           | `abc1234`   | `0.0.0-dev+abc1234`            |
+| `minor`    | `alpha`       | `dev`       | `v1.2.3`         | 0             | `abc1234`   | `1.2.3`                        |
+| `minor`    | `alpha`       | `dev`       | `v1.2.3`         | 10            | `abc1234`   | `1.3.0-dev.10+abc1234`         |
+| `preminor` | `alpha`       | `dev`       | `v1.2.3`         | 10            | `abc1234`   | `1.3.0-alpha.0.dev.10+abc1234` |
+| `preminor` | `alpha`       | `dev`       | `v1.2.3`         | 10            | `abc1234`   | `1.3.0-alpha.0.dev.10+abc1234` |
+| `preminor` | `alpha`       | `dev`       | `v1.2.3-alpha.3` | 10            | `abc1234`   | `1.2.3-alpha.4.dev.10+abc1234` |
+| `minor`    | `alpha`       | `dev`       | `v1.2.3-alpha.3` | 10            | `abc1234`   | `1.2.3-alpha.4.dev.10+abc1234` |
+| `preminor` | `beta`        | `dev`       | `v1.2.3-alpha.3` | 10            | `abc1234`   | `1.2.3-beta.0.dev.10+abc1234`  |
+
+### Algorithm
+
+![version from git algorithm][]
+
+[version from git algorithm]: https://user-images.githubusercontent.com/2963448/113524970-31df4380-9580-11eb-8508-c1968cb017f9.png

--- a/git-version/README.md
+++ b/git-version/README.md
@@ -42,7 +42,7 @@ steps:
 
 | name      | description                      | example                       |
 | --------- | -------------------------------- | ----------------------------- |
-| `version` | Calculated version for the build | `${{ secrets.GITHUB_TOKEN }}` |
+| `version` | Calculated version for the build | `1.3.0-dev.10+abc1234`  |
 
 ### Example versions
 

--- a/git-version/action.yml
+++ b/git-version/action.yml
@@ -1,0 +1,29 @@
+name: 'Get Version From Git'
+author: 'Opentrons Labworks <engineering@opentrons.com>'
+description: 'Get a version string for a build using git metadata'
+inputs:
+  github-token:
+    description: 'GitHub access token, usually {{ secrets.GITHUB_TOKEN }}'
+    required: true
+  tag-prefix:
+    description: 'Prefix to use when matching tags'
+    required: false
+    default: 'v'
+  bump:
+    description: 'Bump to apply to the latest tag, if commit is past tag'
+    required: false
+    default: 'minor'
+  snapshot-id:
+    description: 'Identifier to add to the version to mark it as a snapshot'
+    required: false
+    default: 'dev'
+  prerelease-id:
+    description: 'If `bump` starts with `pre`, prerelease identifier to use'
+    required: false
+    default: 'alpha'
+outputs:
+  version:
+    description: 'The semantic version string'
+runs:
+  using: 'node12'
+  main: 'dist/main.js'

--- a/git-version/dist/main.js
+++ b/git-version/dist/main.js
@@ -1,0 +1,6847 @@
+'use strict';
+
+var fs_1 = require('fs');
+var require$$0 = require('os');
+var http = require('http');
+var https = require('https');
+require('net');
+var tls = require('tls');
+var events = require('events');
+require('assert');
+var util = require('util');
+var Stream = require('stream');
+var Url = require('url');
+var zlib = require('zlib');
+var require$$1 = require('path');
+
+function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
+
+var fs_1__default = /*#__PURE__*/_interopDefaultLegacy(fs_1);
+var require$$0__default = /*#__PURE__*/_interopDefaultLegacy(require$$0);
+var http__default = /*#__PURE__*/_interopDefaultLegacy(http);
+var https__default = /*#__PURE__*/_interopDefaultLegacy(https);
+var tls__default = /*#__PURE__*/_interopDefaultLegacy(tls);
+var events__default = /*#__PURE__*/_interopDefaultLegacy(events);
+var util__default = /*#__PURE__*/_interopDefaultLegacy(util);
+var Stream__default = /*#__PURE__*/_interopDefaultLegacy(Stream);
+var Url__default = /*#__PURE__*/_interopDefaultLegacy(Url);
+var zlib__default = /*#__PURE__*/_interopDefaultLegacy(zlib);
+var require$$1__default = /*#__PURE__*/_interopDefaultLegacy(require$$1);
+
+var commonjsGlobal = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
+
+function getDefaultExportFromCjs (x) {
+	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+}
+
+function getAugmentedNamespace(n) {
+	if (n.__esModule) return n;
+	var a = Object.defineProperty({}, '__esModule', {value: true});
+	Object.keys(n).forEach(function (k) {
+		var d = Object.getOwnPropertyDescriptor(n, k);
+		Object.defineProperty(a, k, d.get ? d : {
+			enumerable: true,
+			get: function () {
+				return n[k];
+			}
+		});
+	});
+	return a;
+}
+
+function createCommonjsModule(fn) {
+  var module = { exports: {} };
+	return fn(module, module.exports), module.exports;
+}
+
+var context = createCommonjsModule(function (module, exports) {
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Context = void 0;
+
+
+class Context {
+    /**
+     * Hydrate the context from the environment
+     */
+    constructor() {
+        this.payload = {};
+        if (process.env.GITHUB_EVENT_PATH) {
+            if (fs_1__default['default'].existsSync(process.env.GITHUB_EVENT_PATH)) {
+                this.payload = JSON.parse(fs_1__default['default'].readFileSync(process.env.GITHUB_EVENT_PATH, { encoding: 'utf8' }));
+            }
+            else {
+                const path = process.env.GITHUB_EVENT_PATH;
+                process.stdout.write(`GITHUB_EVENT_PATH ${path} does not exist${require$$0__default['default'].EOL}`);
+            }
+        }
+        this.eventName = process.env.GITHUB_EVENT_NAME;
+        this.sha = process.env.GITHUB_SHA;
+        this.ref = process.env.GITHUB_REF;
+        this.workflow = process.env.GITHUB_WORKFLOW;
+        this.action = process.env.GITHUB_ACTION;
+        this.actor = process.env.GITHUB_ACTOR;
+        this.job = process.env.GITHUB_JOB;
+        this.runNumber = parseInt(process.env.GITHUB_RUN_NUMBER, 10);
+        this.runId = parseInt(process.env.GITHUB_RUN_ID, 10);
+    }
+    get issue() {
+        const payload = this.payload;
+        return Object.assign(Object.assign({}, this.repo), { number: (payload.issue || payload.pull_request || payload).number });
+    }
+    get repo() {
+        if (process.env.GITHUB_REPOSITORY) {
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+            return { owner, repo };
+        }
+        if (this.payload.repository) {
+            return {
+                owner: this.payload.repository.owner.login,
+                repo: this.payload.repository.name
+            };
+        }
+        throw new Error("context.repo requires a GITHUB_REPOSITORY environment variable like 'owner/repo'");
+    }
+}
+exports.Context = Context;
+//# sourceMappingURL=context.js.map
+});
+
+function getProxyUrl(reqUrl) {
+    let usingSsl = reqUrl.protocol === 'https:';
+    let proxyUrl;
+    if (checkBypass(reqUrl)) {
+        return proxyUrl;
+    }
+    let proxyVar;
+    if (usingSsl) {
+        proxyVar = process.env['https_proxy'] || process.env['HTTPS_PROXY'];
+    }
+    else {
+        proxyVar = process.env['http_proxy'] || process.env['HTTP_PROXY'];
+    }
+    if (proxyVar) {
+        proxyUrl = new URL(proxyVar);
+    }
+    return proxyUrl;
+}
+var getProxyUrl_1 = getProxyUrl;
+function checkBypass(reqUrl) {
+    if (!reqUrl.hostname) {
+        return false;
+    }
+    let noProxy = process.env['no_proxy'] || process.env['NO_PROXY'] || '';
+    if (!noProxy) {
+        return false;
+    }
+    // Determine the request port
+    let reqPort;
+    if (reqUrl.port) {
+        reqPort = Number(reqUrl.port);
+    }
+    else if (reqUrl.protocol === 'http:') {
+        reqPort = 80;
+    }
+    else if (reqUrl.protocol === 'https:') {
+        reqPort = 443;
+    }
+    // Format the request hostname and hostname with port
+    let upperReqHosts = [reqUrl.hostname.toUpperCase()];
+    if (typeof reqPort === 'number') {
+        upperReqHosts.push(`${upperReqHosts[0]}:${reqPort}`);
+    }
+    // Compare request host against noproxy
+    for (let upperNoProxyItem of noProxy
+        .split(',')
+        .map(x => x.trim().toUpperCase())
+        .filter(x => x)) {
+        if (upperReqHosts.some(x => x === upperNoProxyItem)) {
+            return true;
+        }
+    }
+    return false;
+}
+var checkBypass_1 = checkBypass;
+
+var proxy = /*#__PURE__*/Object.defineProperty({
+	getProxyUrl: getProxyUrl_1,
+	checkBypass: checkBypass_1
+}, '__esModule', {value: true});
+
+var httpOverHttp_1 = httpOverHttp;
+var httpsOverHttp_1 = httpsOverHttp;
+var httpOverHttps_1 = httpOverHttps;
+var httpsOverHttps_1 = httpsOverHttps;
+
+
+function httpOverHttp(options) {
+  var agent = new TunnelingAgent(options);
+  agent.request = http__default['default'].request;
+  return agent;
+}
+
+function httpsOverHttp(options) {
+  var agent = new TunnelingAgent(options);
+  agent.request = http__default['default'].request;
+  agent.createSocket = createSecureSocket;
+  agent.defaultPort = 443;
+  return agent;
+}
+
+function httpOverHttps(options) {
+  var agent = new TunnelingAgent(options);
+  agent.request = https__default['default'].request;
+  return agent;
+}
+
+function httpsOverHttps(options) {
+  var agent = new TunnelingAgent(options);
+  agent.request = https__default['default'].request;
+  agent.createSocket = createSecureSocket;
+  agent.defaultPort = 443;
+  return agent;
+}
+
+
+function TunnelingAgent(options) {
+  var self = this;
+  self.options = options || {};
+  self.proxyOptions = self.options.proxy || {};
+  self.maxSockets = self.options.maxSockets || http__default['default'].Agent.defaultMaxSockets;
+  self.requests = [];
+  self.sockets = [];
+
+  self.on('free', function onFree(socket, host, port, localAddress) {
+    var options = toOptions(host, port, localAddress);
+    for (var i = 0, len = self.requests.length; i < len; ++i) {
+      var pending = self.requests[i];
+      if (pending.host === options.host && pending.port === options.port) {
+        // Detect the request to connect same origin server,
+        // reuse the connection.
+        self.requests.splice(i, 1);
+        pending.request.onSocket(socket);
+        return;
+      }
+    }
+    socket.destroy();
+    self.removeSocket(socket);
+  });
+}
+util__default['default'].inherits(TunnelingAgent, events__default['default'].EventEmitter);
+
+TunnelingAgent.prototype.addRequest = function addRequest(req, host, port, localAddress) {
+  var self = this;
+  var options = mergeOptions({request: req}, self.options, toOptions(host, port, localAddress));
+
+  if (self.sockets.length >= this.maxSockets) {
+    // We are over limit so we'll add it to the queue.
+    self.requests.push(options);
+    return;
+  }
+
+  // If we are under maxSockets create a new one.
+  self.createSocket(options, function(socket) {
+    socket.on('free', onFree);
+    socket.on('close', onCloseOrRemove);
+    socket.on('agentRemove', onCloseOrRemove);
+    req.onSocket(socket);
+
+    function onFree() {
+      self.emit('free', socket, options);
+    }
+
+    function onCloseOrRemove(err) {
+      self.removeSocket(socket);
+      socket.removeListener('free', onFree);
+      socket.removeListener('close', onCloseOrRemove);
+      socket.removeListener('agentRemove', onCloseOrRemove);
+    }
+  });
+};
+
+TunnelingAgent.prototype.createSocket = function createSocket(options, cb) {
+  var self = this;
+  var placeholder = {};
+  self.sockets.push(placeholder);
+
+  var connectOptions = mergeOptions({}, self.proxyOptions, {
+    method: 'CONNECT',
+    path: options.host + ':' + options.port,
+    agent: false,
+    headers: {
+      host: options.host + ':' + options.port
+    }
+  });
+  if (options.localAddress) {
+    connectOptions.localAddress = options.localAddress;
+  }
+  if (connectOptions.proxyAuth) {
+    connectOptions.headers = connectOptions.headers || {};
+    connectOptions.headers['Proxy-Authorization'] = 'Basic ' +
+        new Buffer(connectOptions.proxyAuth).toString('base64');
+  }
+
+  debug$1('making CONNECT request');
+  var connectReq = self.request(connectOptions);
+  connectReq.useChunkedEncodingByDefault = false; // for v0.6
+  connectReq.once('response', onResponse); // for v0.6
+  connectReq.once('upgrade', onUpgrade);   // for v0.6
+  connectReq.once('connect', onConnect);   // for v0.7 or later
+  connectReq.once('error', onError);
+  connectReq.end();
+
+  function onResponse(res) {
+    // Very hacky. This is necessary to avoid http-parser leaks.
+    res.upgrade = true;
+  }
+
+  function onUpgrade(res, socket, head) {
+    // Hacky.
+    process.nextTick(function() {
+      onConnect(res, socket, head);
+    });
+  }
+
+  function onConnect(res, socket, head) {
+    connectReq.removeAllListeners();
+    socket.removeAllListeners();
+
+    if (res.statusCode !== 200) {
+      debug$1('tunneling socket could not be established, statusCode=%d',
+        res.statusCode);
+      socket.destroy();
+      var error = new Error('tunneling socket could not be established, ' +
+        'statusCode=' + res.statusCode);
+      error.code = 'ECONNRESET';
+      options.request.emit('error', error);
+      self.removeSocket(placeholder);
+      return;
+    }
+    if (head.length > 0) {
+      debug$1('got illegal response body from proxy');
+      socket.destroy();
+      var error = new Error('got illegal response body from proxy');
+      error.code = 'ECONNRESET';
+      options.request.emit('error', error);
+      self.removeSocket(placeholder);
+      return;
+    }
+    debug$1('tunneling connection has established');
+    self.sockets[self.sockets.indexOf(placeholder)] = socket;
+    return cb(socket);
+  }
+
+  function onError(cause) {
+    connectReq.removeAllListeners();
+
+    debug$1('tunneling socket could not be established, cause=%s\n',
+          cause.message, cause.stack);
+    var error = new Error('tunneling socket could not be established, ' +
+                          'cause=' + cause.message);
+    error.code = 'ECONNRESET';
+    options.request.emit('error', error);
+    self.removeSocket(placeholder);
+  }
+};
+
+TunnelingAgent.prototype.removeSocket = function removeSocket(socket) {
+  var pos = this.sockets.indexOf(socket);
+  if (pos === -1) {
+    return;
+  }
+  this.sockets.splice(pos, 1);
+
+  var pending = this.requests.shift();
+  if (pending) {
+    // If we have pending requests and a socket gets closed a new one
+    // needs to be created to take over in the pool for the one that closed.
+    this.createSocket(pending, function(socket) {
+      pending.request.onSocket(socket);
+    });
+  }
+};
+
+function createSecureSocket(options, cb) {
+  var self = this;
+  TunnelingAgent.prototype.createSocket.call(self, options, function(socket) {
+    var hostHeader = options.request.getHeader('host');
+    var tlsOptions = mergeOptions({}, self.options, {
+      socket: socket,
+      servername: hostHeader ? hostHeader.replace(/:.*$/, '') : options.host
+    });
+
+    // 0 is dummy port for v0.6
+    var secureSocket = tls__default['default'].connect(0, tlsOptions);
+    self.sockets[self.sockets.indexOf(socket)] = secureSocket;
+    cb(secureSocket);
+  });
+}
+
+
+function toOptions(host, port, localAddress) {
+  if (typeof host === 'string') { // since v0.10
+    return {
+      host: host,
+      port: port,
+      localAddress: localAddress
+    };
+  }
+  return host; // for v0.11 or later
+}
+
+function mergeOptions(target) {
+  for (var i = 1, len = arguments.length; i < len; ++i) {
+    var overrides = arguments[i];
+    if (typeof overrides === 'object') {
+      var keys = Object.keys(overrides);
+      for (var j = 0, keyLen = keys.length; j < keyLen; ++j) {
+        var k = keys[j];
+        if (overrides[k] !== undefined) {
+          target[k] = overrides[k];
+        }
+      }
+    }
+  }
+  return target;
+}
+
+
+var debug$1;
+if (process.env.NODE_DEBUG && /\btunnel\b/.test(process.env.NODE_DEBUG)) {
+  debug$1 = function() {
+    var args = Array.prototype.slice.call(arguments);
+    if (typeof args[0] === 'string') {
+      args[0] = 'TUNNEL: ' + args[0];
+    } else {
+      args.unshift('TUNNEL:');
+    }
+    console.error.apply(console, args);
+  };
+} else {
+  debug$1 = function() {};
+}
+var debug_1$1 = debug$1; // for test
+
+var tunnel$1 = {
+	httpOverHttp: httpOverHttp_1,
+	httpsOverHttp: httpsOverHttp_1,
+	httpOverHttps: httpOverHttps_1,
+	httpsOverHttps: httpsOverHttps_1,
+	debug: debug_1$1
+};
+
+var tunnel = tunnel$1;
+
+var httpClient = createCommonjsModule(function (module, exports) {
+Object.defineProperty(exports, "__esModule", { value: true });
+
+
+
+let tunnel$1;
+var HttpCodes;
+(function (HttpCodes) {
+    HttpCodes[HttpCodes["OK"] = 200] = "OK";
+    HttpCodes[HttpCodes["MultipleChoices"] = 300] = "MultipleChoices";
+    HttpCodes[HttpCodes["MovedPermanently"] = 301] = "MovedPermanently";
+    HttpCodes[HttpCodes["ResourceMoved"] = 302] = "ResourceMoved";
+    HttpCodes[HttpCodes["SeeOther"] = 303] = "SeeOther";
+    HttpCodes[HttpCodes["NotModified"] = 304] = "NotModified";
+    HttpCodes[HttpCodes["UseProxy"] = 305] = "UseProxy";
+    HttpCodes[HttpCodes["SwitchProxy"] = 306] = "SwitchProxy";
+    HttpCodes[HttpCodes["TemporaryRedirect"] = 307] = "TemporaryRedirect";
+    HttpCodes[HttpCodes["PermanentRedirect"] = 308] = "PermanentRedirect";
+    HttpCodes[HttpCodes["BadRequest"] = 400] = "BadRequest";
+    HttpCodes[HttpCodes["Unauthorized"] = 401] = "Unauthorized";
+    HttpCodes[HttpCodes["PaymentRequired"] = 402] = "PaymentRequired";
+    HttpCodes[HttpCodes["Forbidden"] = 403] = "Forbidden";
+    HttpCodes[HttpCodes["NotFound"] = 404] = "NotFound";
+    HttpCodes[HttpCodes["MethodNotAllowed"] = 405] = "MethodNotAllowed";
+    HttpCodes[HttpCodes["NotAcceptable"] = 406] = "NotAcceptable";
+    HttpCodes[HttpCodes["ProxyAuthenticationRequired"] = 407] = "ProxyAuthenticationRequired";
+    HttpCodes[HttpCodes["RequestTimeout"] = 408] = "RequestTimeout";
+    HttpCodes[HttpCodes["Conflict"] = 409] = "Conflict";
+    HttpCodes[HttpCodes["Gone"] = 410] = "Gone";
+    HttpCodes[HttpCodes["TooManyRequests"] = 429] = "TooManyRequests";
+    HttpCodes[HttpCodes["InternalServerError"] = 500] = "InternalServerError";
+    HttpCodes[HttpCodes["NotImplemented"] = 501] = "NotImplemented";
+    HttpCodes[HttpCodes["BadGateway"] = 502] = "BadGateway";
+    HttpCodes[HttpCodes["ServiceUnavailable"] = 503] = "ServiceUnavailable";
+    HttpCodes[HttpCodes["GatewayTimeout"] = 504] = "GatewayTimeout";
+})(HttpCodes = exports.HttpCodes || (exports.HttpCodes = {}));
+var Headers;
+(function (Headers) {
+    Headers["Accept"] = "accept";
+    Headers["ContentType"] = "content-type";
+})(Headers = exports.Headers || (exports.Headers = {}));
+var MediaTypes;
+(function (MediaTypes) {
+    MediaTypes["ApplicationJson"] = "application/json";
+})(MediaTypes = exports.MediaTypes || (exports.MediaTypes = {}));
+/**
+ * Returns the proxy URL, depending upon the supplied url and proxy environment variables.
+ * @param serverUrl  The server URL where the request will be sent. For example, https://api.github.com
+ */
+function getProxyUrl(serverUrl) {
+    let proxyUrl = proxy.getProxyUrl(new URL(serverUrl));
+    return proxyUrl ? proxyUrl.href : '';
+}
+exports.getProxyUrl = getProxyUrl;
+const HttpRedirectCodes = [
+    HttpCodes.MovedPermanently,
+    HttpCodes.ResourceMoved,
+    HttpCodes.SeeOther,
+    HttpCodes.TemporaryRedirect,
+    HttpCodes.PermanentRedirect
+];
+const HttpResponseRetryCodes = [
+    HttpCodes.BadGateway,
+    HttpCodes.ServiceUnavailable,
+    HttpCodes.GatewayTimeout
+];
+const RetryableHttpVerbs = ['OPTIONS', 'GET', 'DELETE', 'HEAD'];
+const ExponentialBackoffCeiling = 10;
+const ExponentialBackoffTimeSlice = 5;
+class HttpClientError extends Error {
+    constructor(message, statusCode) {
+        super(message);
+        this.name = 'HttpClientError';
+        this.statusCode = statusCode;
+        Object.setPrototypeOf(this, HttpClientError.prototype);
+    }
+}
+exports.HttpClientError = HttpClientError;
+class HttpClientResponse {
+    constructor(message) {
+        this.message = message;
+    }
+    readBody() {
+        return new Promise(async (resolve, reject) => {
+            let output = Buffer.alloc(0);
+            this.message.on('data', (chunk) => {
+                output = Buffer.concat([output, chunk]);
+            });
+            this.message.on('end', () => {
+                resolve(output.toString());
+            });
+        });
+    }
+}
+exports.HttpClientResponse = HttpClientResponse;
+function isHttps(requestUrl) {
+    let parsedUrl = new URL(requestUrl);
+    return parsedUrl.protocol === 'https:';
+}
+exports.isHttps = isHttps;
+class HttpClient {
+    constructor(userAgent, handlers, requestOptions) {
+        this._ignoreSslError = false;
+        this._allowRedirects = true;
+        this._allowRedirectDowngrade = false;
+        this._maxRedirects = 50;
+        this._allowRetries = false;
+        this._maxRetries = 1;
+        this._keepAlive = false;
+        this._disposed = false;
+        this.userAgent = userAgent;
+        this.handlers = handlers || [];
+        this.requestOptions = requestOptions;
+        if (requestOptions) {
+            if (requestOptions.ignoreSslError != null) {
+                this._ignoreSslError = requestOptions.ignoreSslError;
+            }
+            this._socketTimeout = requestOptions.socketTimeout;
+            if (requestOptions.allowRedirects != null) {
+                this._allowRedirects = requestOptions.allowRedirects;
+            }
+            if (requestOptions.allowRedirectDowngrade != null) {
+                this._allowRedirectDowngrade = requestOptions.allowRedirectDowngrade;
+            }
+            if (requestOptions.maxRedirects != null) {
+                this._maxRedirects = Math.max(requestOptions.maxRedirects, 0);
+            }
+            if (requestOptions.keepAlive != null) {
+                this._keepAlive = requestOptions.keepAlive;
+            }
+            if (requestOptions.allowRetries != null) {
+                this._allowRetries = requestOptions.allowRetries;
+            }
+            if (requestOptions.maxRetries != null) {
+                this._maxRetries = requestOptions.maxRetries;
+            }
+        }
+    }
+    options(requestUrl, additionalHeaders) {
+        return this.request('OPTIONS', requestUrl, null, additionalHeaders || {});
+    }
+    get(requestUrl, additionalHeaders) {
+        return this.request('GET', requestUrl, null, additionalHeaders || {});
+    }
+    del(requestUrl, additionalHeaders) {
+        return this.request('DELETE', requestUrl, null, additionalHeaders || {});
+    }
+    post(requestUrl, data, additionalHeaders) {
+        return this.request('POST', requestUrl, data, additionalHeaders || {});
+    }
+    patch(requestUrl, data, additionalHeaders) {
+        return this.request('PATCH', requestUrl, data, additionalHeaders || {});
+    }
+    put(requestUrl, data, additionalHeaders) {
+        return this.request('PUT', requestUrl, data, additionalHeaders || {});
+    }
+    head(requestUrl, additionalHeaders) {
+        return this.request('HEAD', requestUrl, null, additionalHeaders || {});
+    }
+    sendStream(verb, requestUrl, stream, additionalHeaders) {
+        return this.request(verb, requestUrl, stream, additionalHeaders);
+    }
+    /**
+     * Gets a typed object from an endpoint
+     * Be aware that not found returns a null.  Other errors (4xx, 5xx) reject the promise
+     */
+    async getJson(requestUrl, additionalHeaders = {}) {
+        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
+        let res = await this.get(requestUrl, additionalHeaders);
+        return this._processResponse(res, this.requestOptions);
+    }
+    async postJson(requestUrl, obj, additionalHeaders = {}) {
+        let data = JSON.stringify(obj, null, 2);
+        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
+        additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
+        let res = await this.post(requestUrl, data, additionalHeaders);
+        return this._processResponse(res, this.requestOptions);
+    }
+    async putJson(requestUrl, obj, additionalHeaders = {}) {
+        let data = JSON.stringify(obj, null, 2);
+        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
+        additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
+        let res = await this.put(requestUrl, data, additionalHeaders);
+        return this._processResponse(res, this.requestOptions);
+    }
+    async patchJson(requestUrl, obj, additionalHeaders = {}) {
+        let data = JSON.stringify(obj, null, 2);
+        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
+        additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
+        let res = await this.patch(requestUrl, data, additionalHeaders);
+        return this._processResponse(res, this.requestOptions);
+    }
+    /**
+     * Makes a raw http request.
+     * All other methods such as get, post, patch, and request ultimately call this.
+     * Prefer get, del, post and patch
+     */
+    async request(verb, requestUrl, data, headers) {
+        if (this._disposed) {
+            throw new Error('Client has already been disposed.');
+        }
+        let parsedUrl = new URL(requestUrl);
+        let info = this._prepareRequest(verb, parsedUrl, headers);
+        // Only perform retries on reads since writes may not be idempotent.
+        let maxTries = this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1
+            ? this._maxRetries + 1
+            : 1;
+        let numTries = 0;
+        let response;
+        while (numTries < maxTries) {
+            response = await this.requestRaw(info, data);
+            // Check if it's an authentication challenge
+            if (response &&
+                response.message &&
+                response.message.statusCode === HttpCodes.Unauthorized) {
+                let authenticationHandler;
+                for (let i = 0; i < this.handlers.length; i++) {
+                    if (this.handlers[i].canHandleAuthentication(response)) {
+                        authenticationHandler = this.handlers[i];
+                        break;
+                    }
+                }
+                if (authenticationHandler) {
+                    return authenticationHandler.handleAuthentication(this, info, data);
+                }
+                else {
+                    // We have received an unauthorized response but have no handlers to handle it.
+                    // Let the response return to the caller.
+                    return response;
+                }
+            }
+            let redirectsRemaining = this._maxRedirects;
+            while (HttpRedirectCodes.indexOf(response.message.statusCode) != -1 &&
+                this._allowRedirects &&
+                redirectsRemaining > 0) {
+                const redirectUrl = response.message.headers['location'];
+                if (!redirectUrl) {
+                    // if there's no location to redirect to, we won't
+                    break;
+                }
+                let parsedRedirectUrl = new URL(redirectUrl);
+                if (parsedUrl.protocol == 'https:' &&
+                    parsedUrl.protocol != parsedRedirectUrl.protocol &&
+                    !this._allowRedirectDowngrade) {
+                    throw new Error('Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.');
+                }
+                // we need to finish reading the response before reassigning response
+                // which will leak the open socket.
+                await response.readBody();
+                // strip authorization header if redirected to a different hostname
+                if (parsedRedirectUrl.hostname !== parsedUrl.hostname) {
+                    for (let header in headers) {
+                        // header names are case insensitive
+                        if (header.toLowerCase() === 'authorization') {
+                            delete headers[header];
+                        }
+                    }
+                }
+                // let's make the request with the new redirectUrl
+                info = this._prepareRequest(verb, parsedRedirectUrl, headers);
+                response = await this.requestRaw(info, data);
+                redirectsRemaining--;
+            }
+            if (HttpResponseRetryCodes.indexOf(response.message.statusCode) == -1) {
+                // If not a retry code, return immediately instead of retrying
+                return response;
+            }
+            numTries += 1;
+            if (numTries < maxTries) {
+                await response.readBody();
+                await this._performExponentialBackoff(numTries);
+            }
+        }
+        return response;
+    }
+    /**
+     * Needs to be called if keepAlive is set to true in request options.
+     */
+    dispose() {
+        if (this._agent) {
+            this._agent.destroy();
+        }
+        this._disposed = true;
+    }
+    /**
+     * Raw request.
+     * @param info
+     * @param data
+     */
+    requestRaw(info, data) {
+        return new Promise((resolve, reject) => {
+            let callbackForResult = function (err, res) {
+                if (err) {
+                    reject(err);
+                }
+                resolve(res);
+            };
+            this.requestRawWithCallback(info, data, callbackForResult);
+        });
+    }
+    /**
+     * Raw request with callback.
+     * @param info
+     * @param data
+     * @param onResult
+     */
+    requestRawWithCallback(info, data, onResult) {
+        let socket;
+        if (typeof data === 'string') {
+            info.options.headers['Content-Length'] = Buffer.byteLength(data, 'utf8');
+        }
+        let callbackCalled = false;
+        let handleResult = (err, res) => {
+            if (!callbackCalled) {
+                callbackCalled = true;
+                onResult(err, res);
+            }
+        };
+        let req = info.httpModule.request(info.options, (msg) => {
+            let res = new HttpClientResponse(msg);
+            handleResult(null, res);
+        });
+        req.on('socket', sock => {
+            socket = sock;
+        });
+        // If we ever get disconnected, we want the socket to timeout eventually
+        req.setTimeout(this._socketTimeout || 3 * 60000, () => {
+            if (socket) {
+                socket.end();
+            }
+            handleResult(new Error('Request timeout: ' + info.options.path), null);
+        });
+        req.on('error', function (err) {
+            // err has statusCode property
+            // res should have headers
+            handleResult(err, null);
+        });
+        if (data && typeof data === 'string') {
+            req.write(data, 'utf8');
+        }
+        if (data && typeof data !== 'string') {
+            data.on('close', function () {
+                req.end();
+            });
+            data.pipe(req);
+        }
+        else {
+            req.end();
+        }
+    }
+    /**
+     * Gets an http agent. This function is useful when you need an http agent that handles
+     * routing through a proxy server - depending upon the url and proxy environment variables.
+     * @param serverUrl  The server URL where the request will be sent. For example, https://api.github.com
+     */
+    getAgent(serverUrl) {
+        let parsedUrl = new URL(serverUrl);
+        return this._getAgent(parsedUrl);
+    }
+    _prepareRequest(method, requestUrl, headers) {
+        const info = {};
+        info.parsedUrl = requestUrl;
+        const usingSsl = info.parsedUrl.protocol === 'https:';
+        info.httpModule = usingSsl ? https__default['default'] : http__default['default'];
+        const defaultPort = usingSsl ? 443 : 80;
+        info.options = {};
+        info.options.host = info.parsedUrl.hostname;
+        info.options.port = info.parsedUrl.port
+            ? parseInt(info.parsedUrl.port)
+            : defaultPort;
+        info.options.path =
+            (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
+        info.options.method = method;
+        info.options.headers = this._mergeHeaders(headers);
+        if (this.userAgent != null) {
+            info.options.headers['user-agent'] = this.userAgent;
+        }
+        info.options.agent = this._getAgent(info.parsedUrl);
+        // gives handlers an opportunity to participate
+        if (this.handlers) {
+            this.handlers.forEach(handler => {
+                handler.prepareRequest(info.options);
+            });
+        }
+        return info;
+    }
+    _mergeHeaders(headers) {
+        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
+        if (this.requestOptions && this.requestOptions.headers) {
+            return Object.assign({}, lowercaseKeys(this.requestOptions.headers), lowercaseKeys(headers));
+        }
+        return lowercaseKeys(headers || {});
+    }
+    _getExistingOrDefaultHeader(additionalHeaders, header, _default) {
+        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
+        let clientHeader;
+        if (this.requestOptions && this.requestOptions.headers) {
+            clientHeader = lowercaseKeys(this.requestOptions.headers)[header];
+        }
+        return additionalHeaders[header] || clientHeader || _default;
+    }
+    _getAgent(parsedUrl) {
+        let agent;
+        let proxyUrl = proxy.getProxyUrl(parsedUrl);
+        let useProxy = proxyUrl && proxyUrl.hostname;
+        if (this._keepAlive && useProxy) {
+            agent = this._proxyAgent;
+        }
+        if (this._keepAlive && !useProxy) {
+            agent = this._agent;
+        }
+        // if agent is already assigned use that agent.
+        if (!!agent) {
+            return agent;
+        }
+        const usingSsl = parsedUrl.protocol === 'https:';
+        let maxSockets = 100;
+        if (!!this.requestOptions) {
+            maxSockets = this.requestOptions.maxSockets || http__default['default'].globalAgent.maxSockets;
+        }
+        if (useProxy) {
+            // If using proxy, need tunnel
+            if (!tunnel$1) {
+                tunnel$1 = tunnel;
+            }
+            const agentOptions = {
+                maxSockets: maxSockets,
+                keepAlive: this._keepAlive,
+                proxy: {
+                    ...((proxyUrl.username || proxyUrl.password) && {
+                        proxyAuth: `${proxyUrl.username}:${proxyUrl.password}`
+                    }),
+                    host: proxyUrl.hostname,
+                    port: proxyUrl.port
+                }
+            };
+            let tunnelAgent;
+            const overHttps = proxyUrl.protocol === 'https:';
+            if (usingSsl) {
+                tunnelAgent = overHttps ? tunnel$1.httpsOverHttps : tunnel$1.httpsOverHttp;
+            }
+            else {
+                tunnelAgent = overHttps ? tunnel$1.httpOverHttps : tunnel$1.httpOverHttp;
+            }
+            agent = tunnelAgent(agentOptions);
+            this._proxyAgent = agent;
+        }
+        // if reusing agent across request and tunneling agent isn't assigned create a new agent
+        if (this._keepAlive && !agent) {
+            const options = { keepAlive: this._keepAlive, maxSockets: maxSockets };
+            agent = usingSsl ? new https__default['default'].Agent(options) : new http__default['default'].Agent(options);
+            this._agent = agent;
+        }
+        // if not using private agent and tunnel agent isn't setup then use global agent
+        if (!agent) {
+            agent = usingSsl ? https__default['default'].globalAgent : http__default['default'].globalAgent;
+        }
+        if (usingSsl && this._ignoreSslError) {
+            // we don't want to set NODE_TLS_REJECT_UNAUTHORIZED=0 since that will affect request for entire process
+            // http.RequestOptions doesn't expose a way to modify RequestOptions.agent.options
+            // we have to cast it to any and change it directly
+            agent.options = Object.assign(agent.options || {}, {
+                rejectUnauthorized: false
+            });
+        }
+        return agent;
+    }
+    _performExponentialBackoff(retryNumber) {
+        retryNumber = Math.min(ExponentialBackoffCeiling, retryNumber);
+        const ms = ExponentialBackoffTimeSlice * Math.pow(2, retryNumber);
+        return new Promise(resolve => setTimeout(() => resolve(), ms));
+    }
+    static dateTimeDeserializer(key, value) {
+        if (typeof value === 'string') {
+            let a = new Date(value);
+            if (!isNaN(a.valueOf())) {
+                return a;
+            }
+        }
+        return value;
+    }
+    async _processResponse(res, options) {
+        return new Promise(async (resolve, reject) => {
+            const statusCode = res.message.statusCode;
+            const response = {
+                statusCode: statusCode,
+                result: null,
+                headers: {}
+            };
+            // not found leads to null obj returned
+            if (statusCode == HttpCodes.NotFound) {
+                resolve(response);
+            }
+            let obj;
+            let contents;
+            // get the result from the body
+            try {
+                contents = await res.readBody();
+                if (contents && contents.length > 0) {
+                    if (options && options.deserializeDates) {
+                        obj = JSON.parse(contents, HttpClient.dateTimeDeserializer);
+                    }
+                    else {
+                        obj = JSON.parse(contents);
+                    }
+                    response.result = obj;
+                }
+                response.headers = res.message.headers;
+            }
+            catch (err) {
+                // Invalid resource (contents not json);  leaving result obj null
+            }
+            // note that 3xx redirects are handled by the http layer.
+            if (statusCode > 299) {
+                let msg;
+                // if exception/error in body, attempt to get better error
+                if (obj && obj.message) {
+                    msg = obj.message;
+                }
+                else if (contents && contents.length > 0) {
+                    // it may be the case that the exception is in the body message as string
+                    msg = contents;
+                }
+                else {
+                    msg = 'Failed request: (' + statusCode + ')';
+                }
+                let err = new HttpClientError(msg, statusCode);
+                err.result = response.result;
+                reject(err);
+            }
+            else {
+                resolve(response);
+            }
+        });
+    }
+}
+exports.HttpClient = HttpClient;
+});
+
+var utils$2 = createCommonjsModule(function (module, exports) {
+var __createBinding = (commonjsGlobal && commonjsGlobal.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (commonjsGlobal && commonjsGlobal.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (commonjsGlobal && commonjsGlobal.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getApiBaseUrl = exports.getProxyAgent = exports.getAuthString = void 0;
+const httpClient$1 = __importStar(httpClient);
+function getAuthString(token, options) {
+    if (!token && !options.auth) {
+        throw new Error('Parameter token or opts.auth is required');
+    }
+    else if (token && options.auth) {
+        throw new Error('Parameters token and opts.auth may not both be specified');
+    }
+    return typeof options.auth === 'string' ? options.auth : `token ${token}`;
+}
+exports.getAuthString = getAuthString;
+function getProxyAgent(destinationUrl) {
+    const hc = new httpClient$1.HttpClient();
+    return hc.getAgent(destinationUrl);
+}
+exports.getProxyAgent = getProxyAgent;
+function getApiBaseUrl() {
+    return process.env['GITHUB_API_URL'] || 'https://api.github.com';
+}
+exports.getApiBaseUrl = getApiBaseUrl;
+//# sourceMappingURL=utils.js.map
+});
+
+function getUserAgent() {
+    if (typeof navigator === "object" && "userAgent" in navigator) {
+        return navigator.userAgent;
+    }
+    if (typeof process === "object" && "version" in process) {
+        return `Node.js/${process.version.substr(1)} (${process.platform}; ${process.arch})`;
+    }
+    return "<environment undetectable>";
+}
+
+var register_1 = register;
+
+function register(state, name, method, options) {
+  if (typeof method !== "function") {
+    throw new Error("method for before hook must be a function");
+  }
+
+  if (!options) {
+    options = {};
+  }
+
+  if (Array.isArray(name)) {
+    return name.reverse().reduce(function (callback, name) {
+      return register.bind(null, state, name, callback, options);
+    }, method)();
+  }
+
+  return Promise.resolve().then(function () {
+    if (!state.registry[name]) {
+      return method(options);
+    }
+
+    return state.registry[name].reduce(function (method, registered) {
+      return registered.hook.bind(null, method, options);
+    }, method)();
+  });
+}
+
+var add = addHook;
+
+function addHook(state, kind, name, hook) {
+  var orig = hook;
+  if (!state.registry[name]) {
+    state.registry[name] = [];
+  }
+
+  if (kind === "before") {
+    hook = function (method, options) {
+      return Promise.resolve()
+        .then(orig.bind(null, options))
+        .then(method.bind(null, options));
+    };
+  }
+
+  if (kind === "after") {
+    hook = function (method, options) {
+      var result;
+      return Promise.resolve()
+        .then(method.bind(null, options))
+        .then(function (result_) {
+          result = result_;
+          return orig(result, options);
+        })
+        .then(function () {
+          return result;
+        });
+    };
+  }
+
+  if (kind === "error") {
+    hook = function (method, options) {
+      return Promise.resolve()
+        .then(method.bind(null, options))
+        .catch(function (error) {
+          return orig(error, options);
+        });
+    };
+  }
+
+  state.registry[name].push({
+    hook: hook,
+    orig: orig,
+  });
+}
+
+var remove = removeHook;
+
+function removeHook(state, name, method) {
+  if (!state.registry[name]) {
+    return;
+  }
+
+  var index = state.registry[name]
+    .map(function (registered) {
+      return registered.orig;
+    })
+    .indexOf(method);
+
+  if (index === -1) {
+    return;
+  }
+
+  state.registry[name].splice(index, 1);
+}
+
+// bind with array of arguments: https://stackoverflow.com/a/21792913
+var bind = Function.bind;
+var bindable = bind.bind(bind);
+
+function bindApi (hook, state, name) {
+  var removeHookRef = bindable(remove, null).apply(null, name ? [state, name] : [state]);
+  hook.api = { remove: removeHookRef };
+  hook.remove = removeHookRef
+
+  ;['before', 'error', 'after', 'wrap'].forEach(function (kind) {
+    var args = name ? [state, kind, name] : [state, kind];
+    hook[kind] = hook.api[kind] = bindable(add, null).apply(null, args);
+  });
+}
+
+function HookSingular () {
+  var singularHookName = 'h';
+  var singularHookState = {
+    registry: {}
+  };
+  var singularHook = register_1.bind(null, singularHookState, singularHookName);
+  bindApi(singularHook, singularHookState, singularHookName);
+  return singularHook
+}
+
+function HookCollection () {
+  var state = {
+    registry: {}
+  };
+
+  var hook = register_1.bind(null, state);
+  bindApi(hook, state);
+
+  return hook
+}
+
+var collectionHookDeprecationMessageDisplayed = false;
+function Hook () {
+  if (!collectionHookDeprecationMessageDisplayed) {
+    console.warn('[before-after-hook]: "Hook()" repurposing warning, use "Hook.Collection()". Read more: https://git.io/upgrade-before-after-hook-to-1.4');
+    collectionHookDeprecationMessageDisplayed = true;
+  }
+  return HookCollection()
+}
+
+Hook.Singular = HookSingular.bind();
+Hook.Collection = HookCollection.bind();
+
+var beforeAfterHook = Hook;
+// expose constructors as a named property for TypeScript
+var Hook_1 = Hook;
+var Singular = Hook.Singular;
+var Collection = Hook.Collection;
+beforeAfterHook.Hook = Hook_1;
+beforeAfterHook.Singular = Singular;
+beforeAfterHook.Collection = Collection;
+
+/*!
+ * is-plain-object <https://github.com/jonschlinkert/is-plain-object>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+function isObject$1(o) {
+  return Object.prototype.toString.call(o) === '[object Object]';
+}
+
+function isPlainObject$1(o) {
+  var ctor,prot;
+
+  if (isObject$1(o) === false) return false;
+
+  // If has modified constructor
+  ctor = o.constructor;
+  if (ctor === undefined) return true;
+
+  // If has modified prototype
+  prot = ctor.prototype;
+  if (isObject$1(prot) === false) return false;
+
+  // If constructor does not have an Object-specific method
+  if (prot.hasOwnProperty('isPrototypeOf') === false) {
+    return false;
+  }
+
+  // Most likely a plain Object
+  return true;
+}
+
+function lowercaseKeys(object) {
+    if (!object) {
+        return {};
+    }
+    return Object.keys(object).reduce((newObj, key) => {
+        newObj[key.toLowerCase()] = object[key];
+        return newObj;
+    }, {});
+}
+
+function mergeDeep(defaults, options) {
+    const result = Object.assign({}, defaults);
+    Object.keys(options).forEach((key) => {
+        if (isPlainObject$1(options[key])) {
+            if (!(key in defaults))
+                Object.assign(result, { [key]: options[key] });
+            else
+                result[key] = mergeDeep(defaults[key], options[key]);
+        }
+        else {
+            Object.assign(result, { [key]: options[key] });
+        }
+    });
+    return result;
+}
+
+function removeUndefinedProperties(obj) {
+    for (const key in obj) {
+        if (obj[key] === undefined) {
+            delete obj[key];
+        }
+    }
+    return obj;
+}
+
+function merge(defaults, route, options) {
+    if (typeof route === "string") {
+        let [method, url] = route.split(" ");
+        options = Object.assign(url ? { method, url } : { url: method }, options);
+    }
+    else {
+        options = Object.assign({}, route);
+    }
+    // lowercase header names before merging with defaults to avoid duplicates
+    options.headers = lowercaseKeys(options.headers);
+    // remove properties with undefined values before merging
+    removeUndefinedProperties(options);
+    removeUndefinedProperties(options.headers);
+    const mergedOptions = mergeDeep(defaults || {}, options);
+    // mediaType.previews arrays are merged, instead of overwritten
+    if (defaults && defaults.mediaType.previews.length) {
+        mergedOptions.mediaType.previews = defaults.mediaType.previews
+            .filter((preview) => !mergedOptions.mediaType.previews.includes(preview))
+            .concat(mergedOptions.mediaType.previews);
+    }
+    mergedOptions.mediaType.previews = mergedOptions.mediaType.previews.map((preview) => preview.replace(/-preview/, ""));
+    return mergedOptions;
+}
+
+function addQueryParameters(url, parameters) {
+    const separator = /\?/.test(url) ? "&" : "?";
+    const names = Object.keys(parameters);
+    if (names.length === 0) {
+        return url;
+    }
+    return (url +
+        separator +
+        names
+            .map((name) => {
+            if (name === "q") {
+                return ("q=" + parameters.q.split("+").map(encodeURIComponent).join("+"));
+            }
+            return `${name}=${encodeURIComponent(parameters[name])}`;
+        })
+            .join("&"));
+}
+
+const urlVariableRegex = /\{[^}]+\}/g;
+function removeNonChars(variableName) {
+    return variableName.replace(/^\W+|\W+$/g, "").split(/,/);
+}
+function extractUrlVariableNames(url) {
+    const matches = url.match(urlVariableRegex);
+    if (!matches) {
+        return [];
+    }
+    return matches.map(removeNonChars).reduce((a, b) => a.concat(b), []);
+}
+
+function omit(object, keysToOmit) {
+    return Object.keys(object)
+        .filter((option) => !keysToOmit.includes(option))
+        .reduce((obj, key) => {
+        obj[key] = object[key];
+        return obj;
+    }, {});
+}
+
+// Based on https://github.com/bramstein/url-template, licensed under BSD
+// TODO: create separate package.
+//
+// Copyright (c) 2012-2014, Bram Stein
+// All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  1. Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//  3. The name of the author may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+// EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+// EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/* istanbul ignore file */
+function encodeReserved(str) {
+    return str
+        .split(/(%[0-9A-Fa-f]{2})/g)
+        .map(function (part) {
+        if (!/%[0-9A-Fa-f]/.test(part)) {
+            part = encodeURI(part).replace(/%5B/g, "[").replace(/%5D/g, "]");
+        }
+        return part;
+    })
+        .join("");
+}
+function encodeUnreserved(str) {
+    return encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
+        return "%" + c.charCodeAt(0).toString(16).toUpperCase();
+    });
+}
+function encodeValue(operator, value, key) {
+    value =
+        operator === "+" || operator === "#"
+            ? encodeReserved(value)
+            : encodeUnreserved(value);
+    if (key) {
+        return encodeUnreserved(key) + "=" + value;
+    }
+    else {
+        return value;
+    }
+}
+function isDefined(value) {
+    return value !== undefined && value !== null;
+}
+function isKeyOperator(operator) {
+    return operator === ";" || operator === "&" || operator === "?";
+}
+function getValues(context, operator, key, modifier) {
+    var value = context[key], result = [];
+    if (isDefined(value) && value !== "") {
+        if (typeof value === "string" ||
+            typeof value === "number" ||
+            typeof value === "boolean") {
+            value = value.toString();
+            if (modifier && modifier !== "*") {
+                value = value.substring(0, parseInt(modifier, 10));
+            }
+            result.push(encodeValue(operator, value, isKeyOperator(operator) ? key : ""));
+        }
+        else {
+            if (modifier === "*") {
+                if (Array.isArray(value)) {
+                    value.filter(isDefined).forEach(function (value) {
+                        result.push(encodeValue(operator, value, isKeyOperator(operator) ? key : ""));
+                    });
+                }
+                else {
+                    Object.keys(value).forEach(function (k) {
+                        if (isDefined(value[k])) {
+                            result.push(encodeValue(operator, value[k], k));
+                        }
+                    });
+                }
+            }
+            else {
+                const tmp = [];
+                if (Array.isArray(value)) {
+                    value.filter(isDefined).forEach(function (value) {
+                        tmp.push(encodeValue(operator, value));
+                    });
+                }
+                else {
+                    Object.keys(value).forEach(function (k) {
+                        if (isDefined(value[k])) {
+                            tmp.push(encodeUnreserved(k));
+                            tmp.push(encodeValue(operator, value[k].toString()));
+                        }
+                    });
+                }
+                if (isKeyOperator(operator)) {
+                    result.push(encodeUnreserved(key) + "=" + tmp.join(","));
+                }
+                else if (tmp.length !== 0) {
+                    result.push(tmp.join(","));
+                }
+            }
+        }
+    }
+    else {
+        if (operator === ";") {
+            if (isDefined(value)) {
+                result.push(encodeUnreserved(key));
+            }
+        }
+        else if (value === "" && (operator === "&" || operator === "?")) {
+            result.push(encodeUnreserved(key) + "=");
+        }
+        else if (value === "") {
+            result.push("");
+        }
+    }
+    return result;
+}
+function parseUrl(template) {
+    return {
+        expand: expand.bind(null, template),
+    };
+}
+function expand(template, context) {
+    var operators = ["+", "#", ".", "/", ";", "?", "&"];
+    return template.replace(/\{([^\{\}]+)\}|([^\{\}]+)/g, function (_, expression, literal) {
+        if (expression) {
+            let operator = "";
+            const values = [];
+            if (operators.indexOf(expression.charAt(0)) !== -1) {
+                operator = expression.charAt(0);
+                expression = expression.substr(1);
+            }
+            expression.split(/,/g).forEach(function (variable) {
+                var tmp = /([^:\*]*)(?::(\d+)|(\*))?/.exec(variable);
+                values.push(getValues(context, operator, tmp[1], tmp[2] || tmp[3]));
+            });
+            if (operator && operator !== "+") {
+                var separator = ",";
+                if (operator === "?") {
+                    separator = "&";
+                }
+                else if (operator !== "#") {
+                    separator = operator;
+                }
+                return (values.length !== 0 ? operator : "") + values.join(separator);
+            }
+            else {
+                return values.join(",");
+            }
+        }
+        else {
+            return encodeReserved(literal);
+        }
+    });
+}
+
+function parse$1(options) {
+    // https://fetch.spec.whatwg.org/#methods
+    let method = options.method.toUpperCase();
+    // replace :varname with {varname} to make it RFC 6570 compatible
+    let url = (options.url || "/").replace(/:([a-z]\w+)/g, "{$1}");
+    let headers = Object.assign({}, options.headers);
+    let body;
+    let parameters = omit(options, [
+        "method",
+        "baseUrl",
+        "url",
+        "headers",
+        "request",
+        "mediaType",
+    ]);
+    // extract variable names from URL to calculate remaining variables later
+    const urlVariableNames = extractUrlVariableNames(url);
+    url = parseUrl(url).expand(parameters);
+    if (!/^http/.test(url)) {
+        url = options.baseUrl + url;
+    }
+    const omittedParameters = Object.keys(options)
+        .filter((option) => urlVariableNames.includes(option))
+        .concat("baseUrl");
+    const remainingParameters = omit(parameters, omittedParameters);
+    const isBinaryRequest = /application\/octet-stream/i.test(headers.accept);
+    if (!isBinaryRequest) {
+        if (options.mediaType.format) {
+            // e.g. application/vnd.github.v3+json => application/vnd.github.v3.raw
+            headers.accept = headers.accept
+                .split(/,/)
+                .map((preview) => preview.replace(/application\/vnd(\.\w+)(\.v3)?(\.\w+)?(\+json)?$/, `application/vnd$1$2.${options.mediaType.format}`))
+                .join(",");
+        }
+        if (options.mediaType.previews.length) {
+            const previewsFromAcceptHeader = headers.accept.match(/[\w-]+(?=-preview)/g) || [];
+            headers.accept = previewsFromAcceptHeader
+                .concat(options.mediaType.previews)
+                .map((preview) => {
+                const format = options.mediaType.format
+                    ? `.${options.mediaType.format}`
+                    : "+json";
+                return `application/vnd.github.${preview}-preview${format}`;
+            })
+                .join(",");
+        }
+    }
+    // for GET/HEAD requests, set URL query parameters from remaining parameters
+    // for PATCH/POST/PUT/DELETE requests, set request body from remaining parameters
+    if (["GET", "HEAD"].includes(method)) {
+        url = addQueryParameters(url, remainingParameters);
+    }
+    else {
+        if ("data" in remainingParameters) {
+            body = remainingParameters.data;
+        }
+        else {
+            if (Object.keys(remainingParameters).length) {
+                body = remainingParameters;
+            }
+            else {
+                headers["content-length"] = 0;
+            }
+        }
+    }
+    // default content-type for JSON if body is set
+    if (!headers["content-type"] && typeof body !== "undefined") {
+        headers["content-type"] = "application/json; charset=utf-8";
+    }
+    // GitHub expects 'content-length: 0' header for PUT/PATCH requests without body.
+    // fetch does not allow to set `content-length` header, but we can set body to an empty string
+    if (["PATCH", "PUT"].includes(method) && typeof body === "undefined") {
+        body = "";
+    }
+    // Only return body/request keys if present
+    return Object.assign({ method, url, headers }, typeof body !== "undefined" ? { body } : null, options.request ? { request: options.request } : null);
+}
+
+function endpointWithDefaults(defaults, route, options) {
+    return parse$1(merge(defaults, route, options));
+}
+
+function withDefaults$2(oldDefaults, newDefaults) {
+    const DEFAULTS = merge(oldDefaults, newDefaults);
+    const endpoint = endpointWithDefaults.bind(null, DEFAULTS);
+    return Object.assign(endpoint, {
+        DEFAULTS,
+        defaults: withDefaults$2.bind(null, DEFAULTS),
+        merge: merge.bind(null, DEFAULTS),
+        parse: parse$1,
+    });
+}
+
+const VERSION$5 = "6.0.11";
+
+const userAgent = `octokit-endpoint.js/${VERSION$5} ${getUserAgent()}`;
+// DEFAULTS has all properties set that EndpointOptions has, except url.
+// So we use RequestParameters and add method as additional required property.
+const DEFAULTS = {
+    method: "GET",
+    baseUrl: "https://api.github.com",
+    headers: {
+        accept: "application/vnd.github.v3+json",
+        "user-agent": userAgent,
+    },
+    mediaType: {
+        format: "",
+        previews: [],
+    },
+};
+
+const endpoint = withDefaults$2(null, DEFAULTS);
+
+/*!
+ * is-plain-object <https://github.com/jonschlinkert/is-plain-object>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+function isObject(o) {
+  return Object.prototype.toString.call(o) === '[object Object]';
+}
+
+function isPlainObject(o) {
+  var ctor,prot;
+
+  if (isObject(o) === false) return false;
+
+  // If has modified constructor
+  ctor = o.constructor;
+  if (ctor === undefined) return true;
+
+  // If has modified prototype
+  prot = ctor.prototype;
+  if (isObject(prot) === false) return false;
+
+  // If constructor does not have an Object-specific method
+  if (prot.hasOwnProperty('isPrototypeOf') === false) {
+    return false;
+  }
+
+  // Most likely a plain Object
+  return true;
+}
+
+// Based on https://github.com/tmpvar/jsdom/blob/aa85b2abf07766ff7bf5c1f6daafb3726f2f2db5/lib/jsdom/living/blob.js
+
+// fix for "Readable" isn't a named export issue
+const Readable = Stream__default['default'].Readable;
+
+const BUFFER = Symbol('buffer');
+const TYPE = Symbol('type');
+
+class Blob {
+	constructor() {
+		this[TYPE] = '';
+
+		const blobParts = arguments[0];
+		const options = arguments[1];
+
+		const buffers = [];
+		let size = 0;
+
+		if (blobParts) {
+			const a = blobParts;
+			const length = Number(a.length);
+			for (let i = 0; i < length; i++) {
+				const element = a[i];
+				let buffer;
+				if (element instanceof Buffer) {
+					buffer = element;
+				} else if (ArrayBuffer.isView(element)) {
+					buffer = Buffer.from(element.buffer, element.byteOffset, element.byteLength);
+				} else if (element instanceof ArrayBuffer) {
+					buffer = Buffer.from(element);
+				} else if (element instanceof Blob) {
+					buffer = element[BUFFER];
+				} else {
+					buffer = Buffer.from(typeof element === 'string' ? element : String(element));
+				}
+				size += buffer.length;
+				buffers.push(buffer);
+			}
+		}
+
+		this[BUFFER] = Buffer.concat(buffers);
+
+		let type = options && options.type !== undefined && String(options.type).toLowerCase();
+		if (type && !/[^\u0020-\u007E]/.test(type)) {
+			this[TYPE] = type;
+		}
+	}
+	get size() {
+		return this[BUFFER].length;
+	}
+	get type() {
+		return this[TYPE];
+	}
+	text() {
+		return Promise.resolve(this[BUFFER].toString());
+	}
+	arrayBuffer() {
+		const buf = this[BUFFER];
+		const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+		return Promise.resolve(ab);
+	}
+	stream() {
+		const readable = new Readable();
+		readable._read = function () {};
+		readable.push(this[BUFFER]);
+		readable.push(null);
+		return readable;
+	}
+	toString() {
+		return '[object Blob]';
+	}
+	slice() {
+		const size = this.size;
+
+		const start = arguments[0];
+		const end = arguments[1];
+		let relativeStart, relativeEnd;
+		if (start === undefined) {
+			relativeStart = 0;
+		} else if (start < 0) {
+			relativeStart = Math.max(size + start, 0);
+		} else {
+			relativeStart = Math.min(start, size);
+		}
+		if (end === undefined) {
+			relativeEnd = size;
+		} else if (end < 0) {
+			relativeEnd = Math.max(size + end, 0);
+		} else {
+			relativeEnd = Math.min(end, size);
+		}
+		const span = Math.max(relativeEnd - relativeStart, 0);
+
+		const buffer = this[BUFFER];
+		const slicedBuffer = buffer.slice(relativeStart, relativeStart + span);
+		const blob = new Blob([], { type: arguments[2] });
+		blob[BUFFER] = slicedBuffer;
+		return blob;
+	}
+}
+
+Object.defineProperties(Blob.prototype, {
+	size: { enumerable: true },
+	type: { enumerable: true },
+	slice: { enumerable: true }
+});
+
+Object.defineProperty(Blob.prototype, Symbol.toStringTag, {
+	value: 'Blob',
+	writable: false,
+	enumerable: false,
+	configurable: true
+});
+
+/**
+ * fetch-error.js
+ *
+ * FetchError interface for operational errors
+ */
+
+/**
+ * Create FetchError instance
+ *
+ * @param   String      message      Error message for human
+ * @param   String      type         Error type for machine
+ * @param   String      systemError  For Node.js system error
+ * @return  FetchError
+ */
+function FetchError(message, type, systemError) {
+  Error.call(this, message);
+
+  this.message = message;
+  this.type = type;
+
+  // when err.type is `system`, err.code contains system error code
+  if (systemError) {
+    this.code = this.errno = systemError.code;
+  }
+
+  // hide custom error implementation details from end-users
+  Error.captureStackTrace(this, this.constructor);
+}
+
+FetchError.prototype = Object.create(Error.prototype);
+FetchError.prototype.constructor = FetchError;
+FetchError.prototype.name = 'FetchError';
+
+let convert;
+try {
+	convert = require('encoding').convert;
+} catch (e) {}
+
+const INTERNALS = Symbol('Body internals');
+
+// fix an issue where "PassThrough" isn't a named export for node <10
+const PassThrough = Stream__default['default'].PassThrough;
+
+/**
+ * Body mixin
+ *
+ * Ref: https://fetch.spec.whatwg.org/#body
+ *
+ * @param   Stream  body  Readable stream
+ * @param   Object  opts  Response options
+ * @return  Void
+ */
+function Body(body) {
+	var _this = this;
+
+	var _ref = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+	    _ref$size = _ref.size;
+
+	let size = _ref$size === undefined ? 0 : _ref$size;
+	var _ref$timeout = _ref.timeout;
+	let timeout = _ref$timeout === undefined ? 0 : _ref$timeout;
+
+	if (body == null) {
+		// body is undefined or null
+		body = null;
+	} else if (isURLSearchParams(body)) {
+		// body is a URLSearchParams
+		body = Buffer.from(body.toString());
+	} else if (isBlob(body)) ; else if (Buffer.isBuffer(body)) ; else if (Object.prototype.toString.call(body) === '[object ArrayBuffer]') {
+		// body is ArrayBuffer
+		body = Buffer.from(body);
+	} else if (ArrayBuffer.isView(body)) {
+		// body is ArrayBufferView
+		body = Buffer.from(body.buffer, body.byteOffset, body.byteLength);
+	} else if (body instanceof Stream__default['default']) ; else {
+		// none of the above
+		// coerce to string then buffer
+		body = Buffer.from(String(body));
+	}
+	this[INTERNALS] = {
+		body,
+		disturbed: false,
+		error: null
+	};
+	this.size = size;
+	this.timeout = timeout;
+
+	if (body instanceof Stream__default['default']) {
+		body.on('error', function (err) {
+			const error = err.name === 'AbortError' ? err : new FetchError(`Invalid response body while trying to fetch ${_this.url}: ${err.message}`, 'system', err);
+			_this[INTERNALS].error = error;
+		});
+	}
+}
+
+Body.prototype = {
+	get body() {
+		return this[INTERNALS].body;
+	},
+
+	get bodyUsed() {
+		return this[INTERNALS].disturbed;
+	},
+
+	/**
+  * Decode response as ArrayBuffer
+  *
+  * @return  Promise
+  */
+	arrayBuffer() {
+		return consumeBody.call(this).then(function (buf) {
+			return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+		});
+	},
+
+	/**
+  * Return raw response as Blob
+  *
+  * @return Promise
+  */
+	blob() {
+		let ct = this.headers && this.headers.get('content-type') || '';
+		return consumeBody.call(this).then(function (buf) {
+			return Object.assign(
+			// Prevent copying
+			new Blob([], {
+				type: ct.toLowerCase()
+			}), {
+				[BUFFER]: buf
+			});
+		});
+	},
+
+	/**
+  * Decode response as json
+  *
+  * @return  Promise
+  */
+	json() {
+		var _this2 = this;
+
+		return consumeBody.call(this).then(function (buffer) {
+			try {
+				return JSON.parse(buffer.toString());
+			} catch (err) {
+				return Body.Promise.reject(new FetchError(`invalid json response body at ${_this2.url} reason: ${err.message}`, 'invalid-json'));
+			}
+		});
+	},
+
+	/**
+  * Decode response as text
+  *
+  * @return  Promise
+  */
+	text() {
+		return consumeBody.call(this).then(function (buffer) {
+			return buffer.toString();
+		});
+	},
+
+	/**
+  * Decode response as buffer (non-spec api)
+  *
+  * @return  Promise
+  */
+	buffer() {
+		return consumeBody.call(this);
+	},
+
+	/**
+  * Decode response as text, while automatically detecting the encoding and
+  * trying to decode to UTF-8 (non-spec api)
+  *
+  * @return  Promise
+  */
+	textConverted() {
+		var _this3 = this;
+
+		return consumeBody.call(this).then(function (buffer) {
+			return convertBody(buffer, _this3.headers);
+		});
+	}
+};
+
+// In browsers, all properties are enumerable.
+Object.defineProperties(Body.prototype, {
+	body: { enumerable: true },
+	bodyUsed: { enumerable: true },
+	arrayBuffer: { enumerable: true },
+	blob: { enumerable: true },
+	json: { enumerable: true },
+	text: { enumerable: true }
+});
+
+Body.mixIn = function (proto) {
+	for (const name of Object.getOwnPropertyNames(Body.prototype)) {
+		// istanbul ignore else: future proof
+		if (!(name in proto)) {
+			const desc = Object.getOwnPropertyDescriptor(Body.prototype, name);
+			Object.defineProperty(proto, name, desc);
+		}
+	}
+};
+
+/**
+ * Consume and convert an entire Body to a Buffer.
+ *
+ * Ref: https://fetch.spec.whatwg.org/#concept-body-consume-body
+ *
+ * @return  Promise
+ */
+function consumeBody() {
+	var _this4 = this;
+
+	if (this[INTERNALS].disturbed) {
+		return Body.Promise.reject(new TypeError(`body used already for: ${this.url}`));
+	}
+
+	this[INTERNALS].disturbed = true;
+
+	if (this[INTERNALS].error) {
+		return Body.Promise.reject(this[INTERNALS].error);
+	}
+
+	let body = this.body;
+
+	// body is null
+	if (body === null) {
+		return Body.Promise.resolve(Buffer.alloc(0));
+	}
+
+	// body is blob
+	if (isBlob(body)) {
+		body = body.stream();
+	}
+
+	// body is buffer
+	if (Buffer.isBuffer(body)) {
+		return Body.Promise.resolve(body);
+	}
+
+	// istanbul ignore if: should never happen
+	if (!(body instanceof Stream__default['default'])) {
+		return Body.Promise.resolve(Buffer.alloc(0));
+	}
+
+	// body is stream
+	// get ready to actually consume the body
+	let accum = [];
+	let accumBytes = 0;
+	let abort = false;
+
+	return new Body.Promise(function (resolve, reject) {
+		let resTimeout;
+
+		// allow timeout on slow response body
+		if (_this4.timeout) {
+			resTimeout = setTimeout(function () {
+				abort = true;
+				reject(new FetchError(`Response timeout while trying to fetch ${_this4.url} (over ${_this4.timeout}ms)`, 'body-timeout'));
+			}, _this4.timeout);
+		}
+
+		// handle stream errors
+		body.on('error', function (err) {
+			if (err.name === 'AbortError') {
+				// if the request was aborted, reject with this Error
+				abort = true;
+				reject(err);
+			} else {
+				// other errors, such as incorrect content-encoding
+				reject(new FetchError(`Invalid response body while trying to fetch ${_this4.url}: ${err.message}`, 'system', err));
+			}
+		});
+
+		body.on('data', function (chunk) {
+			if (abort || chunk === null) {
+				return;
+			}
+
+			if (_this4.size && accumBytes + chunk.length > _this4.size) {
+				abort = true;
+				reject(new FetchError(`content size at ${_this4.url} over limit: ${_this4.size}`, 'max-size'));
+				return;
+			}
+
+			accumBytes += chunk.length;
+			accum.push(chunk);
+		});
+
+		body.on('end', function () {
+			if (abort) {
+				return;
+			}
+
+			clearTimeout(resTimeout);
+
+			try {
+				resolve(Buffer.concat(accum, accumBytes));
+			} catch (err) {
+				// handle streams that have accumulated too much data (issue #414)
+				reject(new FetchError(`Could not create Buffer from response body for ${_this4.url}: ${err.message}`, 'system', err));
+			}
+		});
+	});
+}
+
+/**
+ * Detect buffer encoding and convert to target encoding
+ * ref: http://www.w3.org/TR/2011/WD-html5-20110113/parsing.html#determining-the-character-encoding
+ *
+ * @param   Buffer  buffer    Incoming buffer
+ * @param   String  encoding  Target encoding
+ * @return  String
+ */
+function convertBody(buffer, headers) {
+	if (typeof convert !== 'function') {
+		throw new Error('The package `encoding` must be installed to use the textConverted() function');
+	}
+
+	const ct = headers.get('content-type');
+	let charset = 'utf-8';
+	let res, str;
+
+	// header
+	if (ct) {
+		res = /charset=([^;]*)/i.exec(ct);
+	}
+
+	// no charset in content type, peek at response body for at most 1024 bytes
+	str = buffer.slice(0, 1024).toString();
+
+	// html5
+	if (!res && str) {
+		res = /<meta.+?charset=(['"])(.+?)\1/i.exec(str);
+	}
+
+	// html4
+	if (!res && str) {
+		res = /<meta[\s]+?http-equiv=(['"])content-type\1[\s]+?content=(['"])(.+?)\2/i.exec(str);
+		if (!res) {
+			res = /<meta[\s]+?content=(['"])(.+?)\1[\s]+?http-equiv=(['"])content-type\3/i.exec(str);
+			if (res) {
+				res.pop(); // drop last quote
+			}
+		}
+
+		if (res) {
+			res = /charset=(.*)/i.exec(res.pop());
+		}
+	}
+
+	// xml
+	if (!res && str) {
+		res = /<\?xml.+?encoding=(['"])(.+?)\1/i.exec(str);
+	}
+
+	// found charset
+	if (res) {
+		charset = res.pop();
+
+		// prevent decode issues when sites use incorrect encoding
+		// ref: https://hsivonen.fi/encoding-menu/
+		if (charset === 'gb2312' || charset === 'gbk') {
+			charset = 'gb18030';
+		}
+	}
+
+	// turn raw buffers into a single utf-8 buffer
+	return convert(buffer, 'UTF-8', charset).toString();
+}
+
+/**
+ * Detect a URLSearchParams object
+ * ref: https://github.com/bitinn/node-fetch/issues/296#issuecomment-307598143
+ *
+ * @param   Object  obj     Object to detect by type or brand
+ * @return  String
+ */
+function isURLSearchParams(obj) {
+	// Duck-typing as a necessary condition.
+	if (typeof obj !== 'object' || typeof obj.append !== 'function' || typeof obj.delete !== 'function' || typeof obj.get !== 'function' || typeof obj.getAll !== 'function' || typeof obj.has !== 'function' || typeof obj.set !== 'function') {
+		return false;
+	}
+
+	// Brand-checking and more duck-typing as optional condition.
+	return obj.constructor.name === 'URLSearchParams' || Object.prototype.toString.call(obj) === '[object URLSearchParams]' || typeof obj.sort === 'function';
+}
+
+/**
+ * Check if `obj` is a W3C `Blob` object (which `File` inherits from)
+ * @param  {*} obj
+ * @return {boolean}
+ */
+function isBlob(obj) {
+	return typeof obj === 'object' && typeof obj.arrayBuffer === 'function' && typeof obj.type === 'string' && typeof obj.stream === 'function' && typeof obj.constructor === 'function' && typeof obj.constructor.name === 'string' && /^(Blob|File)$/.test(obj.constructor.name) && /^(Blob|File)$/.test(obj[Symbol.toStringTag]);
+}
+
+/**
+ * Clone body given Res/Req instance
+ *
+ * @param   Mixed  instance  Response or Request instance
+ * @return  Mixed
+ */
+function clone(instance) {
+	let p1, p2;
+	let body = instance.body;
+
+	// don't allow cloning a used body
+	if (instance.bodyUsed) {
+		throw new Error('cannot clone body after it is used');
+	}
+
+	// check that body is a stream and not form-data object
+	// note: we can't clone the form-data object without having it as a dependency
+	if (body instanceof Stream__default['default'] && typeof body.getBoundary !== 'function') {
+		// tee instance body
+		p1 = new PassThrough();
+		p2 = new PassThrough();
+		body.pipe(p1);
+		body.pipe(p2);
+		// set instance body to teed body and return the other teed body
+		instance[INTERNALS].body = p1;
+		body = p2;
+	}
+
+	return body;
+}
+
+/**
+ * Performs the operation "extract a `Content-Type` value from |object|" as
+ * specified in the specification:
+ * https://fetch.spec.whatwg.org/#concept-bodyinit-extract
+ *
+ * This function assumes that instance.body is present.
+ *
+ * @param   Mixed  instance  Any options.body input
+ */
+function extractContentType(body) {
+	if (body === null) {
+		// body is null
+		return null;
+	} else if (typeof body === 'string') {
+		// body is string
+		return 'text/plain;charset=UTF-8';
+	} else if (isURLSearchParams(body)) {
+		// body is a URLSearchParams
+		return 'application/x-www-form-urlencoded;charset=UTF-8';
+	} else if (isBlob(body)) {
+		// body is blob
+		return body.type || null;
+	} else if (Buffer.isBuffer(body)) {
+		// body is buffer
+		return null;
+	} else if (Object.prototype.toString.call(body) === '[object ArrayBuffer]') {
+		// body is ArrayBuffer
+		return null;
+	} else if (ArrayBuffer.isView(body)) {
+		// body is ArrayBufferView
+		return null;
+	} else if (typeof body.getBoundary === 'function') {
+		// detect form data input from form-data module
+		return `multipart/form-data;boundary=${body.getBoundary()}`;
+	} else if (body instanceof Stream__default['default']) {
+		// body is stream
+		// can't really do much about this
+		return null;
+	} else {
+		// Body constructor defaults other things to string
+		return 'text/plain;charset=UTF-8';
+	}
+}
+
+/**
+ * The Fetch Standard treats this as if "total bytes" is a property on the body.
+ * For us, we have to explicitly get it with a function.
+ *
+ * ref: https://fetch.spec.whatwg.org/#concept-body-total-bytes
+ *
+ * @param   Body    instance   Instance of Body
+ * @return  Number?            Number of bytes, or null if not possible
+ */
+function getTotalBytes(instance) {
+	const body = instance.body;
+
+
+	if (body === null) {
+		// body is null
+		return 0;
+	} else if (isBlob(body)) {
+		return body.size;
+	} else if (Buffer.isBuffer(body)) {
+		// body is buffer
+		return body.length;
+	} else if (body && typeof body.getLengthSync === 'function') {
+		// detect form data input from form-data module
+		if (body._lengthRetrievers && body._lengthRetrievers.length == 0 || // 1.x
+		body.hasKnownLength && body.hasKnownLength()) {
+			// 2.x
+			return body.getLengthSync();
+		}
+		return null;
+	} else {
+		// body is stream
+		return null;
+	}
+}
+
+/**
+ * Write a Body to a Node.js WritableStream (e.g. http.Request) object.
+ *
+ * @param   Body    instance   Instance of Body
+ * @return  Void
+ */
+function writeToStream(dest, instance) {
+	const body = instance.body;
+
+
+	if (body === null) {
+		// body is null
+		dest.end();
+	} else if (isBlob(body)) {
+		body.stream().pipe(dest);
+	} else if (Buffer.isBuffer(body)) {
+		// body is buffer
+		dest.write(body);
+		dest.end();
+	} else {
+		// body is stream
+		body.pipe(dest);
+	}
+}
+
+// expose Promise
+Body.Promise = global.Promise;
+
+/**
+ * headers.js
+ *
+ * Headers class offers convenient helpers
+ */
+
+const invalidTokenRegex = /[^\^_`a-zA-Z\-0-9!#$%&'*+.|~]/;
+const invalidHeaderCharRegex = /[^\t\x20-\x7e\x80-\xff]/;
+
+function validateName(name) {
+	name = `${name}`;
+	if (invalidTokenRegex.test(name) || name === '') {
+		throw new TypeError(`${name} is not a legal HTTP header name`);
+	}
+}
+
+function validateValue(value) {
+	value = `${value}`;
+	if (invalidHeaderCharRegex.test(value)) {
+		throw new TypeError(`${value} is not a legal HTTP header value`);
+	}
+}
+
+/**
+ * Find the key in the map object given a header name.
+ *
+ * Returns undefined if not found.
+ *
+ * @param   String  name  Header name
+ * @return  String|Undefined
+ */
+function find(map, name) {
+	name = name.toLowerCase();
+	for (const key in map) {
+		if (key.toLowerCase() === name) {
+			return key;
+		}
+	}
+	return undefined;
+}
+
+const MAP = Symbol('map');
+class Headers {
+	/**
+  * Headers class
+  *
+  * @param   Object  headers  Response headers
+  * @return  Void
+  */
+	constructor() {
+		let init = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : undefined;
+
+		this[MAP] = Object.create(null);
+
+		if (init instanceof Headers) {
+			const rawHeaders = init.raw();
+			const headerNames = Object.keys(rawHeaders);
+
+			for (const headerName of headerNames) {
+				for (const value of rawHeaders[headerName]) {
+					this.append(headerName, value);
+				}
+			}
+
+			return;
+		}
+
+		// We don't worry about converting prop to ByteString here as append()
+		// will handle it.
+		if (init == null) ; else if (typeof init === 'object') {
+			const method = init[Symbol.iterator];
+			if (method != null) {
+				if (typeof method !== 'function') {
+					throw new TypeError('Header pairs must be iterable');
+				}
+
+				// sequence<sequence<ByteString>>
+				// Note: per spec we have to first exhaust the lists then process them
+				const pairs = [];
+				for (const pair of init) {
+					if (typeof pair !== 'object' || typeof pair[Symbol.iterator] !== 'function') {
+						throw new TypeError('Each header pair must be iterable');
+					}
+					pairs.push(Array.from(pair));
+				}
+
+				for (const pair of pairs) {
+					if (pair.length !== 2) {
+						throw new TypeError('Each header pair must be a name/value tuple');
+					}
+					this.append(pair[0], pair[1]);
+				}
+			} else {
+				// record<ByteString, ByteString>
+				for (const key of Object.keys(init)) {
+					const value = init[key];
+					this.append(key, value);
+				}
+			}
+		} else {
+			throw new TypeError('Provided initializer must be an object');
+		}
+	}
+
+	/**
+  * Return combined header value given name
+  *
+  * @param   String  name  Header name
+  * @return  Mixed
+  */
+	get(name) {
+		name = `${name}`;
+		validateName(name);
+		const key = find(this[MAP], name);
+		if (key === undefined) {
+			return null;
+		}
+
+		return this[MAP][key].join(', ');
+	}
+
+	/**
+  * Iterate over all headers
+  *
+  * @param   Function  callback  Executed for each item with parameters (value, name, thisArg)
+  * @param   Boolean   thisArg   `this` context for callback function
+  * @return  Void
+  */
+	forEach(callback) {
+		let thisArg = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : undefined;
+
+		let pairs = getHeaders(this);
+		let i = 0;
+		while (i < pairs.length) {
+			var _pairs$i = pairs[i];
+			const name = _pairs$i[0],
+			      value = _pairs$i[1];
+
+			callback.call(thisArg, value, name, this);
+			pairs = getHeaders(this);
+			i++;
+		}
+	}
+
+	/**
+  * Overwrite header values given name
+  *
+  * @param   String  name   Header name
+  * @param   String  value  Header value
+  * @return  Void
+  */
+	set(name, value) {
+		name = `${name}`;
+		value = `${value}`;
+		validateName(name);
+		validateValue(value);
+		const key = find(this[MAP], name);
+		this[MAP][key !== undefined ? key : name] = [value];
+	}
+
+	/**
+  * Append a value onto existing header
+  *
+  * @param   String  name   Header name
+  * @param   String  value  Header value
+  * @return  Void
+  */
+	append(name, value) {
+		name = `${name}`;
+		value = `${value}`;
+		validateName(name);
+		validateValue(value);
+		const key = find(this[MAP], name);
+		if (key !== undefined) {
+			this[MAP][key].push(value);
+		} else {
+			this[MAP][name] = [value];
+		}
+	}
+
+	/**
+  * Check for header name existence
+  *
+  * @param   String   name  Header name
+  * @return  Boolean
+  */
+	has(name) {
+		name = `${name}`;
+		validateName(name);
+		return find(this[MAP], name) !== undefined;
+	}
+
+	/**
+  * Delete all header values given name
+  *
+  * @param   String  name  Header name
+  * @return  Void
+  */
+	delete(name) {
+		name = `${name}`;
+		validateName(name);
+		const key = find(this[MAP], name);
+		if (key !== undefined) {
+			delete this[MAP][key];
+		}
+	}
+
+	/**
+  * Return raw headers (non-spec api)
+  *
+  * @return  Object
+  */
+	raw() {
+		return this[MAP];
+	}
+
+	/**
+  * Get an iterator on keys.
+  *
+  * @return  Iterator
+  */
+	keys() {
+		return createHeadersIterator(this, 'key');
+	}
+
+	/**
+  * Get an iterator on values.
+  *
+  * @return  Iterator
+  */
+	values() {
+		return createHeadersIterator(this, 'value');
+	}
+
+	/**
+  * Get an iterator on entries.
+  *
+  * This is the default iterator of the Headers object.
+  *
+  * @return  Iterator
+  */
+	[Symbol.iterator]() {
+		return createHeadersIterator(this, 'key+value');
+	}
+}
+Headers.prototype.entries = Headers.prototype[Symbol.iterator];
+
+Object.defineProperty(Headers.prototype, Symbol.toStringTag, {
+	value: 'Headers',
+	writable: false,
+	enumerable: false,
+	configurable: true
+});
+
+Object.defineProperties(Headers.prototype, {
+	get: { enumerable: true },
+	forEach: { enumerable: true },
+	set: { enumerable: true },
+	append: { enumerable: true },
+	has: { enumerable: true },
+	delete: { enumerable: true },
+	keys: { enumerable: true },
+	values: { enumerable: true },
+	entries: { enumerable: true }
+});
+
+function getHeaders(headers) {
+	let kind = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'key+value';
+
+	const keys = Object.keys(headers[MAP]).sort();
+	return keys.map(kind === 'key' ? function (k) {
+		return k.toLowerCase();
+	} : kind === 'value' ? function (k) {
+		return headers[MAP][k].join(', ');
+	} : function (k) {
+		return [k.toLowerCase(), headers[MAP][k].join(', ')];
+	});
+}
+
+const INTERNAL = Symbol('internal');
+
+function createHeadersIterator(target, kind) {
+	const iterator = Object.create(HeadersIteratorPrototype);
+	iterator[INTERNAL] = {
+		target,
+		kind,
+		index: 0
+	};
+	return iterator;
+}
+
+const HeadersIteratorPrototype = Object.setPrototypeOf({
+	next() {
+		// istanbul ignore if
+		if (!this || Object.getPrototypeOf(this) !== HeadersIteratorPrototype) {
+			throw new TypeError('Value of `this` is not a HeadersIterator');
+		}
+
+		var _INTERNAL = this[INTERNAL];
+		const target = _INTERNAL.target,
+		      kind = _INTERNAL.kind,
+		      index = _INTERNAL.index;
+
+		const values = getHeaders(target, kind);
+		const len = values.length;
+		if (index >= len) {
+			return {
+				value: undefined,
+				done: true
+			};
+		}
+
+		this[INTERNAL].index = index + 1;
+
+		return {
+			value: values[index],
+			done: false
+		};
+	}
+}, Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]())));
+
+Object.defineProperty(HeadersIteratorPrototype, Symbol.toStringTag, {
+	value: 'HeadersIterator',
+	writable: false,
+	enumerable: false,
+	configurable: true
+});
+
+/**
+ * Export the Headers object in a form that Node.js can consume.
+ *
+ * @param   Headers  headers
+ * @return  Object
+ */
+function exportNodeCompatibleHeaders(headers) {
+	const obj = Object.assign({ __proto__: null }, headers[MAP]);
+
+	// http.request() only supports string as Host header. This hack makes
+	// specifying custom Host header possible.
+	const hostHeaderKey = find(headers[MAP], 'Host');
+	if (hostHeaderKey !== undefined) {
+		obj[hostHeaderKey] = obj[hostHeaderKey][0];
+	}
+
+	return obj;
+}
+
+/**
+ * Create a Headers object from an object of headers, ignoring those that do
+ * not conform to HTTP grammar productions.
+ *
+ * @param   Object  obj  Object of headers
+ * @return  Headers
+ */
+function createHeadersLenient(obj) {
+	const headers = new Headers();
+	for (const name of Object.keys(obj)) {
+		if (invalidTokenRegex.test(name)) {
+			continue;
+		}
+		if (Array.isArray(obj[name])) {
+			for (const val of obj[name]) {
+				if (invalidHeaderCharRegex.test(val)) {
+					continue;
+				}
+				if (headers[MAP][name] === undefined) {
+					headers[MAP][name] = [val];
+				} else {
+					headers[MAP][name].push(val);
+				}
+			}
+		} else if (!invalidHeaderCharRegex.test(obj[name])) {
+			headers[MAP][name] = [obj[name]];
+		}
+	}
+	return headers;
+}
+
+const INTERNALS$1 = Symbol('Response internals');
+
+// fix an issue where "STATUS_CODES" aren't a named export for node <10
+const STATUS_CODES = http__default['default'].STATUS_CODES;
+
+/**
+ * Response class
+ *
+ * @param   Stream  body  Readable stream
+ * @param   Object  opts  Response options
+ * @return  Void
+ */
+class Response {
+	constructor() {
+		let body = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : null;
+		let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+		Body.call(this, body, opts);
+
+		const status = opts.status || 200;
+		const headers = new Headers(opts.headers);
+
+		if (body != null && !headers.has('Content-Type')) {
+			const contentType = extractContentType(body);
+			if (contentType) {
+				headers.append('Content-Type', contentType);
+			}
+		}
+
+		this[INTERNALS$1] = {
+			url: opts.url,
+			status,
+			statusText: opts.statusText || STATUS_CODES[status],
+			headers,
+			counter: opts.counter
+		};
+	}
+
+	get url() {
+		return this[INTERNALS$1].url || '';
+	}
+
+	get status() {
+		return this[INTERNALS$1].status;
+	}
+
+	/**
+  * Convenience property representing if the request ended normally
+  */
+	get ok() {
+		return this[INTERNALS$1].status >= 200 && this[INTERNALS$1].status < 300;
+	}
+
+	get redirected() {
+		return this[INTERNALS$1].counter > 0;
+	}
+
+	get statusText() {
+		return this[INTERNALS$1].statusText;
+	}
+
+	get headers() {
+		return this[INTERNALS$1].headers;
+	}
+
+	/**
+  * Clone this response
+  *
+  * @return  Response
+  */
+	clone() {
+		return new Response(clone(this), {
+			url: this.url,
+			status: this.status,
+			statusText: this.statusText,
+			headers: this.headers,
+			ok: this.ok,
+			redirected: this.redirected
+		});
+	}
+}
+
+Body.mixIn(Response.prototype);
+
+Object.defineProperties(Response.prototype, {
+	url: { enumerable: true },
+	status: { enumerable: true },
+	ok: { enumerable: true },
+	redirected: { enumerable: true },
+	statusText: { enumerable: true },
+	headers: { enumerable: true },
+	clone: { enumerable: true }
+});
+
+Object.defineProperty(Response.prototype, Symbol.toStringTag, {
+	value: 'Response',
+	writable: false,
+	enumerable: false,
+	configurable: true
+});
+
+const INTERNALS$2 = Symbol('Request internals');
+
+// fix an issue where "format", "parse" aren't a named export for node <10
+const parse_url = Url__default['default'].parse;
+const format_url = Url__default['default'].format;
+
+const streamDestructionSupported = 'destroy' in Stream__default['default'].Readable.prototype;
+
+/**
+ * Check if a value is an instance of Request.
+ *
+ * @param   Mixed   input
+ * @return  Boolean
+ */
+function isRequest(input) {
+	return typeof input === 'object' && typeof input[INTERNALS$2] === 'object';
+}
+
+function isAbortSignal(signal) {
+	const proto = signal && typeof signal === 'object' && Object.getPrototypeOf(signal);
+	return !!(proto && proto.constructor.name === 'AbortSignal');
+}
+
+/**
+ * Request class
+ *
+ * @param   Mixed   input  Url or Request instance
+ * @param   Object  init   Custom options
+ * @return  Void
+ */
+class Request {
+	constructor(input) {
+		let init = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+		let parsedURL;
+
+		// normalize input
+		if (!isRequest(input)) {
+			if (input && input.href) {
+				// in order to support Node.js' Url objects; though WHATWG's URL objects
+				// will fall into this branch also (since their `toString()` will return
+				// `href` property anyway)
+				parsedURL = parse_url(input.href);
+			} else {
+				// coerce input to a string before attempting to parse
+				parsedURL = parse_url(`${input}`);
+			}
+			input = {};
+		} else {
+			parsedURL = parse_url(input.url);
+		}
+
+		let method = init.method || input.method || 'GET';
+		method = method.toUpperCase();
+
+		if ((init.body != null || isRequest(input) && input.body !== null) && (method === 'GET' || method === 'HEAD')) {
+			throw new TypeError('Request with GET/HEAD method cannot have body');
+		}
+
+		let inputBody = init.body != null ? init.body : isRequest(input) && input.body !== null ? clone(input) : null;
+
+		Body.call(this, inputBody, {
+			timeout: init.timeout || input.timeout || 0,
+			size: init.size || input.size || 0
+		});
+
+		const headers = new Headers(init.headers || input.headers || {});
+
+		if (inputBody != null && !headers.has('Content-Type')) {
+			const contentType = extractContentType(inputBody);
+			if (contentType) {
+				headers.append('Content-Type', contentType);
+			}
+		}
+
+		let signal = isRequest(input) ? input.signal : null;
+		if ('signal' in init) signal = init.signal;
+
+		if (signal != null && !isAbortSignal(signal)) {
+			throw new TypeError('Expected signal to be an instanceof AbortSignal');
+		}
+
+		this[INTERNALS$2] = {
+			method,
+			redirect: init.redirect || input.redirect || 'follow',
+			headers,
+			parsedURL,
+			signal
+		};
+
+		// node-fetch-only options
+		this.follow = init.follow !== undefined ? init.follow : input.follow !== undefined ? input.follow : 20;
+		this.compress = init.compress !== undefined ? init.compress : input.compress !== undefined ? input.compress : true;
+		this.counter = init.counter || input.counter || 0;
+		this.agent = init.agent || input.agent;
+	}
+
+	get method() {
+		return this[INTERNALS$2].method;
+	}
+
+	get url() {
+		return format_url(this[INTERNALS$2].parsedURL);
+	}
+
+	get headers() {
+		return this[INTERNALS$2].headers;
+	}
+
+	get redirect() {
+		return this[INTERNALS$2].redirect;
+	}
+
+	get signal() {
+		return this[INTERNALS$2].signal;
+	}
+
+	/**
+  * Clone this request
+  *
+  * @return  Request
+  */
+	clone() {
+		return new Request(this);
+	}
+}
+
+Body.mixIn(Request.prototype);
+
+Object.defineProperty(Request.prototype, Symbol.toStringTag, {
+	value: 'Request',
+	writable: false,
+	enumerable: false,
+	configurable: true
+});
+
+Object.defineProperties(Request.prototype, {
+	method: { enumerable: true },
+	url: { enumerable: true },
+	headers: { enumerable: true },
+	redirect: { enumerable: true },
+	clone: { enumerable: true },
+	signal: { enumerable: true }
+});
+
+/**
+ * Convert a Request to Node.js http request options.
+ *
+ * @param   Request  A Request instance
+ * @return  Object   The options object to be passed to http.request
+ */
+function getNodeRequestOptions(request) {
+	const parsedURL = request[INTERNALS$2].parsedURL;
+	const headers = new Headers(request[INTERNALS$2].headers);
+
+	// fetch step 1.3
+	if (!headers.has('Accept')) {
+		headers.set('Accept', '*/*');
+	}
+
+	// Basic fetch
+	if (!parsedURL.protocol || !parsedURL.hostname) {
+		throw new TypeError('Only absolute URLs are supported');
+	}
+
+	if (!/^https?:$/.test(parsedURL.protocol)) {
+		throw new TypeError('Only HTTP(S) protocols are supported');
+	}
+
+	if (request.signal && request.body instanceof Stream__default['default'].Readable && !streamDestructionSupported) {
+		throw new Error('Cancellation of streamed requests with AbortSignal is not supported in node < 8');
+	}
+
+	// HTTP-network-or-cache fetch steps 2.4-2.7
+	let contentLengthValue = null;
+	if (request.body == null && /^(POST|PUT)$/i.test(request.method)) {
+		contentLengthValue = '0';
+	}
+	if (request.body != null) {
+		const totalBytes = getTotalBytes(request);
+		if (typeof totalBytes === 'number') {
+			contentLengthValue = String(totalBytes);
+		}
+	}
+	if (contentLengthValue) {
+		headers.set('Content-Length', contentLengthValue);
+	}
+
+	// HTTP-network-or-cache fetch step 2.11
+	if (!headers.has('User-Agent')) {
+		headers.set('User-Agent', 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)');
+	}
+
+	// HTTP-network-or-cache fetch step 2.15
+	if (request.compress && !headers.has('Accept-Encoding')) {
+		headers.set('Accept-Encoding', 'gzip,deflate');
+	}
+
+	let agent = request.agent;
+	if (typeof agent === 'function') {
+		agent = agent(parsedURL);
+	}
+
+	if (!headers.has('Connection') && !agent) {
+		headers.set('Connection', 'close');
+	}
+
+	// HTTP-network fetch step 4.2
+	// chunked encoding is handled by Node.js
+
+	return Object.assign({}, parsedURL, {
+		method: request.method,
+		headers: exportNodeCompatibleHeaders(headers),
+		agent
+	});
+}
+
+/**
+ * abort-error.js
+ *
+ * AbortError interface for cancelled requests
+ */
+
+/**
+ * Create AbortError instance
+ *
+ * @param   String      message      Error message for human
+ * @return  AbortError
+ */
+function AbortError(message) {
+  Error.call(this, message);
+
+  this.type = 'aborted';
+  this.message = message;
+
+  // hide custom error implementation details from end-users
+  Error.captureStackTrace(this, this.constructor);
+}
+
+AbortError.prototype = Object.create(Error.prototype);
+AbortError.prototype.constructor = AbortError;
+AbortError.prototype.name = 'AbortError';
+
+// fix an issue where "PassThrough", "resolve" aren't a named export for node <10
+const PassThrough$1 = Stream__default['default'].PassThrough;
+const resolve_url = Url__default['default'].resolve;
+
+/**
+ * Fetch function
+ *
+ * @param   Mixed    url   Absolute url or Request instance
+ * @param   Object   opts  Fetch options
+ * @return  Promise
+ */
+function fetch(url, opts) {
+
+	// allow custom promise
+	if (!fetch.Promise) {
+		throw new Error('native promise missing, set fetch.Promise to your favorite alternative');
+	}
+
+	Body.Promise = fetch.Promise;
+
+	// wrap http.request into fetch
+	return new fetch.Promise(function (resolve, reject) {
+		// build request object
+		const request = new Request(url, opts);
+		const options = getNodeRequestOptions(request);
+
+		const send = (options.protocol === 'https:' ? https__default['default'] : http__default['default']).request;
+		const signal = request.signal;
+
+		let response = null;
+
+		const abort = function abort() {
+			let error = new AbortError('The user aborted a request.');
+			reject(error);
+			if (request.body && request.body instanceof Stream__default['default'].Readable) {
+				request.body.destroy(error);
+			}
+			if (!response || !response.body) return;
+			response.body.emit('error', error);
+		};
+
+		if (signal && signal.aborted) {
+			abort();
+			return;
+		}
+
+		const abortAndFinalize = function abortAndFinalize() {
+			abort();
+			finalize();
+		};
+
+		// send request
+		const req = send(options);
+		let reqTimeout;
+
+		if (signal) {
+			signal.addEventListener('abort', abortAndFinalize);
+		}
+
+		function finalize() {
+			req.abort();
+			if (signal) signal.removeEventListener('abort', abortAndFinalize);
+			clearTimeout(reqTimeout);
+		}
+
+		if (request.timeout) {
+			req.once('socket', function (socket) {
+				reqTimeout = setTimeout(function () {
+					reject(new FetchError(`network timeout at: ${request.url}`, 'request-timeout'));
+					finalize();
+				}, request.timeout);
+			});
+		}
+
+		req.on('error', function (err) {
+			reject(new FetchError(`request to ${request.url} failed, reason: ${err.message}`, 'system', err));
+			finalize();
+		});
+
+		req.on('response', function (res) {
+			clearTimeout(reqTimeout);
+
+			const headers = createHeadersLenient(res.headers);
+
+			// HTTP fetch step 5
+			if (fetch.isRedirect(res.statusCode)) {
+				// HTTP fetch step 5.2
+				const location = headers.get('Location');
+
+				// HTTP fetch step 5.3
+				const locationURL = location === null ? null : resolve_url(request.url, location);
+
+				// HTTP fetch step 5.5
+				switch (request.redirect) {
+					case 'error':
+						reject(new FetchError(`uri requested responds with a redirect, redirect mode is set to error: ${request.url}`, 'no-redirect'));
+						finalize();
+						return;
+					case 'manual':
+						// node-fetch-specific step: make manual redirect a bit easier to use by setting the Location header value to the resolved URL.
+						if (locationURL !== null) {
+							// handle corrupted header
+							try {
+								headers.set('Location', locationURL);
+							} catch (err) {
+								// istanbul ignore next: nodejs server prevent invalid response headers, we can't test this through normal request
+								reject(err);
+							}
+						}
+						break;
+					case 'follow':
+						// HTTP-redirect fetch step 2
+						if (locationURL === null) {
+							break;
+						}
+
+						// HTTP-redirect fetch step 5
+						if (request.counter >= request.follow) {
+							reject(new FetchError(`maximum redirect reached at: ${request.url}`, 'max-redirect'));
+							finalize();
+							return;
+						}
+
+						// HTTP-redirect fetch step 6 (counter increment)
+						// Create a new Request object.
+						const requestOpts = {
+							headers: new Headers(request.headers),
+							follow: request.follow,
+							counter: request.counter + 1,
+							agent: request.agent,
+							compress: request.compress,
+							method: request.method,
+							body: request.body,
+							signal: request.signal,
+							timeout: request.timeout,
+							size: request.size
+						};
+
+						// HTTP-redirect fetch step 9
+						if (res.statusCode !== 303 && request.body && getTotalBytes(request) === null) {
+							reject(new FetchError('Cannot follow redirect with body being a readable stream', 'unsupported-redirect'));
+							finalize();
+							return;
+						}
+
+						// HTTP-redirect fetch step 11
+						if (res.statusCode === 303 || (res.statusCode === 301 || res.statusCode === 302) && request.method === 'POST') {
+							requestOpts.method = 'GET';
+							requestOpts.body = undefined;
+							requestOpts.headers.delete('content-length');
+						}
+
+						// HTTP-redirect fetch step 15
+						resolve(fetch(new Request(locationURL, requestOpts)));
+						finalize();
+						return;
+				}
+			}
+
+			// prepare response
+			res.once('end', function () {
+				if (signal) signal.removeEventListener('abort', abortAndFinalize);
+			});
+			let body = res.pipe(new PassThrough$1());
+
+			const response_options = {
+				url: request.url,
+				status: res.statusCode,
+				statusText: res.statusMessage,
+				headers: headers,
+				size: request.size,
+				timeout: request.timeout,
+				counter: request.counter
+			};
+
+			// HTTP-network fetch step 12.1.1.3
+			const codings = headers.get('Content-Encoding');
+
+			// HTTP-network fetch step 12.1.1.4: handle content codings
+
+			// in following scenarios we ignore compression support
+			// 1. compression support is disabled
+			// 2. HEAD request
+			// 3. no Content-Encoding header
+			// 4. no content response (204)
+			// 5. content not modified response (304)
+			if (!request.compress || request.method === 'HEAD' || codings === null || res.statusCode === 204 || res.statusCode === 304) {
+				response = new Response(body, response_options);
+				resolve(response);
+				return;
+			}
+
+			// For Node v6+
+			// Be less strict when decoding compressed responses, since sometimes
+			// servers send slightly invalid responses that are still accepted
+			// by common browsers.
+			// Always using Z_SYNC_FLUSH is what cURL does.
+			const zlibOptions = {
+				flush: zlib__default['default'].Z_SYNC_FLUSH,
+				finishFlush: zlib__default['default'].Z_SYNC_FLUSH
+			};
+
+			// for gzip
+			if (codings == 'gzip' || codings == 'x-gzip') {
+				body = body.pipe(zlib__default['default'].createGunzip(zlibOptions));
+				response = new Response(body, response_options);
+				resolve(response);
+				return;
+			}
+
+			// for deflate
+			if (codings == 'deflate' || codings == 'x-deflate') {
+				// handle the infamous raw deflate response from old servers
+				// a hack for old IIS and Apache servers
+				const raw = res.pipe(new PassThrough$1());
+				raw.once('data', function (chunk) {
+					// see http://stackoverflow.com/questions/37519828
+					if ((chunk[0] & 0x0F) === 0x08) {
+						body = body.pipe(zlib__default['default'].createInflate());
+					} else {
+						body = body.pipe(zlib__default['default'].createInflateRaw());
+					}
+					response = new Response(body, response_options);
+					resolve(response);
+				});
+				return;
+			}
+
+			// for br
+			if (codings == 'br' && typeof zlib__default['default'].createBrotliDecompress === 'function') {
+				body = body.pipe(zlib__default['default'].createBrotliDecompress());
+				response = new Response(body, response_options);
+				resolve(response);
+				return;
+			}
+
+			// otherwise, use response as-is
+			response = new Response(body, response_options);
+			resolve(response);
+		});
+
+		writeToStream(req, request);
+	});
+}
+/**
+ * Redirect code matching
+ *
+ * @param   Number   code  Status code
+ * @return  Boolean
+ */
+fetch.isRedirect = function (code) {
+	return code === 301 || code === 302 || code === 303 || code === 307 || code === 308;
+};
+
+// expose Promise
+fetch.Promise = global.Promise;
+
+class Deprecation extends Error {
+  constructor(message) {
+    super(message); // Maintains proper stack trace (only available on V8)
+
+    /* istanbul ignore next */
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+
+    this.name = 'Deprecation';
+  }
+
+}
+
+// Returns a wrapper function that returns a wrapped callback
+// The wrapper function should do some stuff, and return a
+// presumably different callback function.
+// This makes sure that own properties are retained, so that
+// decorations and such are not lost along the way.
+var wrappy_1 = wrappy;
+function wrappy (fn, cb) {
+  if (fn && cb) return wrappy(fn)(cb)
+
+  if (typeof fn !== 'function')
+    throw new TypeError('need wrapper function')
+
+  Object.keys(fn).forEach(function (k) {
+    wrapper[k] = fn[k];
+  });
+
+  return wrapper
+
+  function wrapper() {
+    var args = new Array(arguments.length);
+    for (var i = 0; i < args.length; i++) {
+      args[i] = arguments[i];
+    }
+    var ret = fn.apply(this, args);
+    var cb = args[args.length-1];
+    if (typeof ret === 'function' && ret !== cb) {
+      Object.keys(cb).forEach(function (k) {
+        ret[k] = cb[k];
+      });
+    }
+    return ret
+  }
+}
+
+var once_1 = wrappy_1(once);
+var strict = wrappy_1(onceStrict);
+
+once.proto = once(function () {
+  Object.defineProperty(Function.prototype, 'once', {
+    value: function () {
+      return once(this)
+    },
+    configurable: true
+  });
+
+  Object.defineProperty(Function.prototype, 'onceStrict', {
+    value: function () {
+      return onceStrict(this)
+    },
+    configurable: true
+  });
+});
+
+function once (fn) {
+  var f = function () {
+    if (f.called) return f.value
+    f.called = true;
+    return f.value = fn.apply(this, arguments)
+  };
+  f.called = false;
+  return f
+}
+
+function onceStrict (fn) {
+  var f = function () {
+    if (f.called)
+      throw new Error(f.onceError)
+    f.called = true;
+    return f.value = fn.apply(this, arguments)
+  };
+  var name = fn.name || 'Function wrapped with `once`';
+  f.onceError = name + " shouldn't be called more than once";
+  f.called = false;
+  return f
+}
+once_1.strict = strict;
+
+const logOnce = once_1((deprecation) => console.warn(deprecation));
+/**
+ * Error with extra properties to help with debugging
+ */
+class RequestError extends Error {
+    constructor(message, statusCode, options) {
+        super(message);
+        // Maintains proper stack trace (only available on V8)
+        /* istanbul ignore next */
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        }
+        this.name = "HttpError";
+        this.status = statusCode;
+        Object.defineProperty(this, "code", {
+            get() {
+                logOnce(new Deprecation("[@octokit/request-error] `error.code` is deprecated, use `error.status`."));
+                return statusCode;
+            },
+        });
+        this.headers = options.headers || {};
+        // redact request credentials without mutating original request options
+        const requestCopy = Object.assign({}, options.request);
+        if (options.request.headers.authorization) {
+            requestCopy.headers = Object.assign({}, options.request.headers, {
+                authorization: options.request.headers.authorization.replace(/ .*$/, " [REDACTED]"),
+            });
+        }
+        requestCopy.url = requestCopy.url
+            // client_id & client_secret can be passed as URL query parameters to increase rate limit
+            // see https://developer.github.com/v3/#increasing-the-unauthenticated-rate-limit-for-oauth-applications
+            .replace(/\bclient_secret=\w+/g, "client_secret=[REDACTED]")
+            // OAuth tokens can be passed as URL query parameters, although it is not recommended
+            // see https://developer.github.com/v3/#oauth2-token-sent-in-a-header
+            .replace(/\baccess_token=\w+/g, "access_token=[REDACTED]");
+        this.request = requestCopy;
+    }
+}
+
+const VERSION$4 = "5.4.14";
+
+function getBufferResponse(response) {
+    return response.arrayBuffer();
+}
+
+function fetchWrapper(requestOptions) {
+    if (isPlainObject(requestOptions.body) ||
+        Array.isArray(requestOptions.body)) {
+        requestOptions.body = JSON.stringify(requestOptions.body);
+    }
+    let headers = {};
+    let status;
+    let url;
+    const fetch$1 = (requestOptions.request && requestOptions.request.fetch) || fetch;
+    return fetch$1(requestOptions.url, Object.assign({
+        method: requestOptions.method,
+        body: requestOptions.body,
+        headers: requestOptions.headers,
+        redirect: requestOptions.redirect,
+    }, requestOptions.request))
+        .then((response) => {
+        url = response.url;
+        status = response.status;
+        for (const keyAndValue of response.headers) {
+            headers[keyAndValue[0]] = keyAndValue[1];
+        }
+        if (status === 204 || status === 205) {
+            return;
+        }
+        // GitHub API returns 200 for HEAD requests
+        if (requestOptions.method === "HEAD") {
+            if (status < 400) {
+                return;
+            }
+            throw new RequestError(response.statusText, status, {
+                headers,
+                request: requestOptions,
+            });
+        }
+        if (status === 304) {
+            throw new RequestError("Not modified", status, {
+                headers,
+                request: requestOptions,
+            });
+        }
+        if (status >= 400) {
+            return response
+                .text()
+                .then((message) => {
+                const error = new RequestError(message, status, {
+                    headers,
+                    request: requestOptions,
+                });
+                try {
+                    let responseBody = JSON.parse(error.message);
+                    Object.assign(error, responseBody);
+                    let errors = responseBody.errors;
+                    // Assumption `errors` would always be in Array format
+                    error.message =
+                        error.message + ": " + errors.map(JSON.stringify).join(", ");
+                }
+                catch (e) {
+                    // ignore, see octokit/rest.js#684
+                }
+                throw error;
+            });
+        }
+        const contentType = response.headers.get("content-type");
+        if (/application\/json/.test(contentType)) {
+            return response.json();
+        }
+        if (!contentType || /^text\/|charset=utf-8$/.test(contentType)) {
+            return response.text();
+        }
+        return getBufferResponse(response);
+    })
+        .then((data) => {
+        return {
+            status,
+            url,
+            headers,
+            data,
+        };
+    })
+        .catch((error) => {
+        if (error instanceof RequestError) {
+            throw error;
+        }
+        throw new RequestError(error.message, 500, {
+            headers,
+            request: requestOptions,
+        });
+    });
+}
+
+function withDefaults$1(oldEndpoint, newDefaults) {
+    const endpoint = oldEndpoint.defaults(newDefaults);
+    const newApi = function (route, parameters) {
+        const endpointOptions = endpoint.merge(route, parameters);
+        if (!endpointOptions.request || !endpointOptions.request.hook) {
+            return fetchWrapper(endpoint.parse(endpointOptions));
+        }
+        const request = (route, parameters) => {
+            return fetchWrapper(endpoint.parse(endpoint.merge(route, parameters)));
+        };
+        Object.assign(request, {
+            endpoint,
+            defaults: withDefaults$1.bind(null, endpoint),
+        });
+        return endpointOptions.request.hook(request, endpointOptions);
+    };
+    return Object.assign(newApi, {
+        endpoint,
+        defaults: withDefaults$1.bind(null, endpoint),
+    });
+}
+
+const request = withDefaults$1(endpoint, {
+    headers: {
+        "user-agent": `octokit-request.js/${VERSION$4} ${getUserAgent()}`,
+    },
+});
+
+const VERSION$3 = "4.6.1";
+
+class GraphqlError extends Error {
+    constructor(request, response) {
+        const message = response.data.errors[0].message;
+        super(message);
+        Object.assign(this, response.data);
+        Object.assign(this, { headers: response.headers });
+        this.name = "GraphqlError";
+        this.request = request;
+        // Maintains proper stack trace (only available on V8)
+        /* istanbul ignore next */
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        }
+    }
+}
+
+const NON_VARIABLE_OPTIONS = [
+    "method",
+    "baseUrl",
+    "url",
+    "headers",
+    "request",
+    "query",
+    "mediaType",
+];
+const FORBIDDEN_VARIABLE_OPTIONS = ["query", "method", "url"];
+const GHES_V3_SUFFIX_REGEX = /\/api\/v3\/?$/;
+function graphql(request, query, options) {
+    if (options) {
+        if (typeof query === "string" && "query" in options) {
+            return Promise.reject(new Error(`[@octokit/graphql] "query" cannot be used as variable name`));
+        }
+        for (const key in options) {
+            if (!FORBIDDEN_VARIABLE_OPTIONS.includes(key))
+                continue;
+            return Promise.reject(new Error(`[@octokit/graphql] "${key}" cannot be used as variable name`));
+        }
+    }
+    const parsedOptions = typeof query === "string" ? Object.assign({ query }, options) : query;
+    const requestOptions = Object.keys(parsedOptions).reduce((result, key) => {
+        if (NON_VARIABLE_OPTIONS.includes(key)) {
+            result[key] = parsedOptions[key];
+            return result;
+        }
+        if (!result.variables) {
+            result.variables = {};
+        }
+        result.variables[key] = parsedOptions[key];
+        return result;
+    }, {});
+    // workaround for GitHub Enterprise baseUrl set with /api/v3 suffix
+    // https://github.com/octokit/auth-app.js/issues/111#issuecomment-657610451
+    const baseUrl = parsedOptions.baseUrl || request.endpoint.DEFAULTS.baseUrl;
+    if (GHES_V3_SUFFIX_REGEX.test(baseUrl)) {
+        requestOptions.url = baseUrl.replace(GHES_V3_SUFFIX_REGEX, "/api/graphql");
+    }
+    return request(requestOptions).then((response) => {
+        if (response.data.errors) {
+            const headers = {};
+            for (const key of Object.keys(response.headers)) {
+                headers[key] = response.headers[key];
+            }
+            throw new GraphqlError(requestOptions, {
+                headers,
+                data: response.data,
+            });
+        }
+        return response.data.data;
+    });
+}
+
+function withDefaults(request$1, newDefaults) {
+    const newRequest = request$1.defaults(newDefaults);
+    const newApi = (query, options) => {
+        return graphql(newRequest, query, options);
+    };
+    return Object.assign(newApi, {
+        defaults: withDefaults.bind(null, newRequest),
+        endpoint: request.endpoint,
+    });
+}
+
+withDefaults(request, {
+    headers: {
+        "user-agent": `octokit-graphql.js/${VERSION$3} ${getUserAgent()}`,
+    },
+    method: "POST",
+    url: "/graphql",
+});
+function withCustomRequest(customRequest) {
+    return withDefaults(customRequest, {
+        method: "POST",
+        url: "/graphql",
+    });
+}
+
+async function auth(token) {
+    const tokenType = token.split(/\./).length === 3
+        ? "app"
+        : /^v\d+\./.test(token)
+            ? "installation"
+            : "oauth";
+    return {
+        type: "token",
+        token: token,
+        tokenType
+    };
+}
+
+/**
+ * Prefix token for usage in the Authorization header
+ *
+ * @param token OAuth token or JSON Web Token
+ */
+function withAuthorizationPrefix(token) {
+    if (token.split(/\./).length === 3) {
+        return `bearer ${token}`;
+    }
+    return `token ${token}`;
+}
+
+async function hook(token, request, route, parameters) {
+    const endpoint = request.endpoint.merge(route, parameters);
+    endpoint.headers.authorization = withAuthorizationPrefix(token);
+    return request(endpoint);
+}
+
+const createTokenAuth = function createTokenAuth(token) {
+    if (!token) {
+        throw new Error("[@octokit/auth-token] No token passed to createTokenAuth");
+    }
+    if (typeof token !== "string") {
+        throw new Error("[@octokit/auth-token] Token passed to createTokenAuth is not a string");
+    }
+    token = token.replace(/^(token|bearer) +/i, "");
+    return Object.assign(auth.bind(null, token), {
+        hook: hook.bind(null, token)
+    });
+};
+
+const VERSION$2 = "3.4.0";
+
+class Octokit {
+    constructor(options = {}) {
+        const hook = new Collection();
+        const requestDefaults = {
+            baseUrl: request.endpoint.DEFAULTS.baseUrl,
+            headers: {},
+            request: Object.assign({}, options.request, {
+                // @ts-ignore internal usage only, no need to type
+                hook: hook.bind(null, "request"),
+            }),
+            mediaType: {
+                previews: [],
+                format: "",
+            },
+        };
+        // prepend default user agent with `options.userAgent` if set
+        requestDefaults.headers["user-agent"] = [
+            options.userAgent,
+            `octokit-core.js/${VERSION$2} ${getUserAgent()}`,
+        ]
+            .filter(Boolean)
+            .join(" ");
+        if (options.baseUrl) {
+            requestDefaults.baseUrl = options.baseUrl;
+        }
+        if (options.previews) {
+            requestDefaults.mediaType.previews = options.previews;
+        }
+        if (options.timeZone) {
+            requestDefaults.headers["time-zone"] = options.timeZone;
+        }
+        this.request = request.defaults(requestDefaults);
+        this.graphql = withCustomRequest(this.request).defaults(requestDefaults);
+        this.log = Object.assign({
+            debug: () => { },
+            info: () => { },
+            warn: console.warn.bind(console),
+            error: console.error.bind(console),
+        }, options.log);
+        this.hook = hook;
+        // (1) If neither `options.authStrategy` nor `options.auth` are set, the `octokit` instance
+        //     is unauthenticated. The `this.auth()` method is a no-op and no request hook is registered.
+        // (2) If only `options.auth` is set, use the default token authentication strategy.
+        // (3) If `options.authStrategy` is set then use it and pass in `options.auth`. Always pass own request as many strategies accept a custom request instance.
+        // TODO: type `options.auth` based on `options.authStrategy`.
+        if (!options.authStrategy) {
+            if (!options.auth) {
+                // (1)
+                this.auth = async () => ({
+                    type: "unauthenticated",
+                });
+            }
+            else {
+                // (2)
+                const auth = createTokenAuth(options.auth);
+                // @ts-ignore  ¯\_(ツ)_/¯
+                hook.wrap("request", auth.hook);
+                this.auth = auth;
+            }
+        }
+        else {
+            const { authStrategy, ...otherOptions } = options;
+            const auth = authStrategy(Object.assign({
+                request: this.request,
+                log: this.log,
+                // we pass the current octokit instance as well as its constructor options
+                // to allow for authentication strategies that return a new octokit instance
+                // that shares the same internal state as the current one. The original
+                // requirement for this was the "event-octokit" authentication strategy
+                // of https://github.com/probot/octokit-auth-probot.
+                octokit: this,
+                octokitOptions: otherOptions,
+            }, options.auth));
+            // @ts-ignore  ¯\_(ツ)_/¯
+            hook.wrap("request", auth.hook);
+            this.auth = auth;
+        }
+        // apply plugins
+        // https://stackoverflow.com/a/16345172
+        const classConstructor = this.constructor;
+        classConstructor.plugins.forEach((plugin) => {
+            Object.assign(this, plugin(this, options));
+        });
+    }
+    static defaults(defaults) {
+        const OctokitWithDefaults = class extends this {
+            constructor(...args) {
+                const options = args[0] || {};
+                if (typeof defaults === "function") {
+                    super(defaults(options));
+                    return;
+                }
+                super(Object.assign({}, defaults, options, options.userAgent && defaults.userAgent
+                    ? {
+                        userAgent: `${options.userAgent} ${defaults.userAgent}`,
+                    }
+                    : null));
+            }
+        };
+        return OctokitWithDefaults;
+    }
+    /**
+     * Attach a plugin (or many) to your Octokit instance.
+     *
+     * @example
+     * const API = Octokit.plugin(plugin1, plugin2, plugin3, ...)
+     */
+    static plugin(...newPlugins) {
+        var _a;
+        const currentPlugins = this.plugins;
+        const NewOctokit = (_a = class extends this {
+            },
+            _a.plugins = currentPlugins.concat(newPlugins.filter((plugin) => !currentPlugins.includes(plugin))),
+            _a);
+        return NewOctokit;
+    }
+}
+Octokit.VERSION = VERSION$2;
+Octokit.plugins = [];
+
+var distWeb$2 = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	Octokit: Octokit
+});
+
+const Endpoints = {
+    actions: {
+        addSelectedRepoToOrgSecret: [
+            "PUT /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}",
+        ],
+        cancelWorkflowRun: [
+            "POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel",
+        ],
+        createOrUpdateEnvironmentSecret: [
+            "PUT /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}",
+        ],
+        createOrUpdateOrgSecret: ["PUT /orgs/{org}/actions/secrets/{secret_name}"],
+        createOrUpdateRepoSecret: [
+            "PUT /repos/{owner}/{repo}/actions/secrets/{secret_name}",
+        ],
+        createRegistrationTokenForOrg: [
+            "POST /orgs/{org}/actions/runners/registration-token",
+        ],
+        createRegistrationTokenForRepo: [
+            "POST /repos/{owner}/{repo}/actions/runners/registration-token",
+        ],
+        createRemoveTokenForOrg: ["POST /orgs/{org}/actions/runners/remove-token"],
+        createRemoveTokenForRepo: [
+            "POST /repos/{owner}/{repo}/actions/runners/remove-token",
+        ],
+        createWorkflowDispatch: [
+            "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
+        ],
+        deleteArtifact: [
+            "DELETE /repos/{owner}/{repo}/actions/artifacts/{artifact_id}",
+        ],
+        deleteEnvironmentSecret: [
+            "DELETE /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}",
+        ],
+        deleteOrgSecret: ["DELETE /orgs/{org}/actions/secrets/{secret_name}"],
+        deleteRepoSecret: [
+            "DELETE /repos/{owner}/{repo}/actions/secrets/{secret_name}",
+        ],
+        deleteSelfHostedRunnerFromOrg: [
+            "DELETE /orgs/{org}/actions/runners/{runner_id}",
+        ],
+        deleteSelfHostedRunnerFromRepo: [
+            "DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}",
+        ],
+        deleteWorkflowRun: ["DELETE /repos/{owner}/{repo}/actions/runs/{run_id}"],
+        deleteWorkflowRunLogs: [
+            "DELETE /repos/{owner}/{repo}/actions/runs/{run_id}/logs",
+        ],
+        disableSelectedRepositoryGithubActionsOrganization: [
+            "DELETE /orgs/{org}/actions/permissions/repositories/{repository_id}",
+        ],
+        disableWorkflow: [
+            "PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/disable",
+        ],
+        downloadArtifact: [
+            "GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}",
+        ],
+        downloadJobLogsForWorkflowRun: [
+            "GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs",
+        ],
+        downloadWorkflowRunLogs: [
+            "GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs",
+        ],
+        enableSelectedRepositoryGithubActionsOrganization: [
+            "PUT /orgs/{org}/actions/permissions/repositories/{repository_id}",
+        ],
+        enableWorkflow: [
+            "PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/enable",
+        ],
+        getAllowedActionsOrganization: [
+            "GET /orgs/{org}/actions/permissions/selected-actions",
+        ],
+        getAllowedActionsRepository: [
+            "GET /repos/{owner}/{repo}/actions/permissions/selected-actions",
+        ],
+        getArtifact: ["GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}"],
+        getEnvironmentPublicKey: [
+            "GET /repositories/{repository_id}/environments/{environment_name}/secrets/public-key",
+        ],
+        getEnvironmentSecret: [
+            "GET /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}",
+        ],
+        getGithubActionsPermissionsOrganization: [
+            "GET /orgs/{org}/actions/permissions",
+        ],
+        getGithubActionsPermissionsRepository: [
+            "GET /repos/{owner}/{repo}/actions/permissions",
+        ],
+        getJobForWorkflowRun: ["GET /repos/{owner}/{repo}/actions/jobs/{job_id}"],
+        getOrgPublicKey: ["GET /orgs/{org}/actions/secrets/public-key"],
+        getOrgSecret: ["GET /orgs/{org}/actions/secrets/{secret_name}"],
+        getPendingDeploymentsForRun: [
+            "GET /repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments",
+        ],
+        getRepoPermissions: [
+            "GET /repos/{owner}/{repo}/actions/permissions",
+            {},
+            { renamed: ["actions", "getGithubActionsPermissionsRepository"] },
+        ],
+        getRepoPublicKey: ["GET /repos/{owner}/{repo}/actions/secrets/public-key"],
+        getRepoSecret: ["GET /repos/{owner}/{repo}/actions/secrets/{secret_name}"],
+        getReviewsForRun: [
+            "GET /repos/{owner}/{repo}/actions/runs/{run_id}/approvals",
+        ],
+        getSelfHostedRunnerForOrg: ["GET /orgs/{org}/actions/runners/{runner_id}"],
+        getSelfHostedRunnerForRepo: [
+            "GET /repos/{owner}/{repo}/actions/runners/{runner_id}",
+        ],
+        getWorkflow: ["GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}"],
+        getWorkflowRun: ["GET /repos/{owner}/{repo}/actions/runs/{run_id}"],
+        getWorkflowRunUsage: [
+            "GET /repos/{owner}/{repo}/actions/runs/{run_id}/timing",
+        ],
+        getWorkflowUsage: [
+            "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/timing",
+        ],
+        listArtifactsForRepo: ["GET /repos/{owner}/{repo}/actions/artifacts"],
+        listEnvironmentSecrets: [
+            "GET /repositories/{repository_id}/environments/{environment_name}/secrets",
+        ],
+        listJobsForWorkflowRun: [
+            "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
+        ],
+        listOrgSecrets: ["GET /orgs/{org}/actions/secrets"],
+        listRepoSecrets: ["GET /repos/{owner}/{repo}/actions/secrets"],
+        listRepoWorkflows: ["GET /repos/{owner}/{repo}/actions/workflows"],
+        listRunnerApplicationsForOrg: ["GET /orgs/{org}/actions/runners/downloads"],
+        listRunnerApplicationsForRepo: [
+            "GET /repos/{owner}/{repo}/actions/runners/downloads",
+        ],
+        listSelectedReposForOrgSecret: [
+            "GET /orgs/{org}/actions/secrets/{secret_name}/repositories",
+        ],
+        listSelectedRepositoriesEnabledGithubActionsOrganization: [
+            "GET /orgs/{org}/actions/permissions/repositories",
+        ],
+        listSelfHostedRunnersForOrg: ["GET /orgs/{org}/actions/runners"],
+        listSelfHostedRunnersForRepo: ["GET /repos/{owner}/{repo}/actions/runners"],
+        listWorkflowRunArtifacts: [
+            "GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts",
+        ],
+        listWorkflowRuns: [
+            "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",
+        ],
+        listWorkflowRunsForRepo: ["GET /repos/{owner}/{repo}/actions/runs"],
+        reRunWorkflow: ["POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun"],
+        removeSelectedRepoFromOrgSecret: [
+            "DELETE /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}",
+        ],
+        reviewPendingDeploymentsForRun: [
+            "POST /repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments",
+        ],
+        setAllowedActionsOrganization: [
+            "PUT /orgs/{org}/actions/permissions/selected-actions",
+        ],
+        setAllowedActionsRepository: [
+            "PUT /repos/{owner}/{repo}/actions/permissions/selected-actions",
+        ],
+        setGithubActionsPermissionsOrganization: [
+            "PUT /orgs/{org}/actions/permissions",
+        ],
+        setGithubActionsPermissionsRepository: [
+            "PUT /repos/{owner}/{repo}/actions/permissions",
+        ],
+        setSelectedReposForOrgSecret: [
+            "PUT /orgs/{org}/actions/secrets/{secret_name}/repositories",
+        ],
+        setSelectedRepositoriesEnabledGithubActionsOrganization: [
+            "PUT /orgs/{org}/actions/permissions/repositories",
+        ],
+    },
+    activity: {
+        checkRepoIsStarredByAuthenticatedUser: ["GET /user/starred/{owner}/{repo}"],
+        deleteRepoSubscription: ["DELETE /repos/{owner}/{repo}/subscription"],
+        deleteThreadSubscription: [
+            "DELETE /notifications/threads/{thread_id}/subscription",
+        ],
+        getFeeds: ["GET /feeds"],
+        getRepoSubscription: ["GET /repos/{owner}/{repo}/subscription"],
+        getThread: ["GET /notifications/threads/{thread_id}"],
+        getThreadSubscriptionForAuthenticatedUser: [
+            "GET /notifications/threads/{thread_id}/subscription",
+        ],
+        listEventsForAuthenticatedUser: ["GET /users/{username}/events"],
+        listNotificationsForAuthenticatedUser: ["GET /notifications"],
+        listOrgEventsForAuthenticatedUser: [
+            "GET /users/{username}/events/orgs/{org}",
+        ],
+        listPublicEvents: ["GET /events"],
+        listPublicEventsForRepoNetwork: ["GET /networks/{owner}/{repo}/events"],
+        listPublicEventsForUser: ["GET /users/{username}/events/public"],
+        listPublicOrgEvents: ["GET /orgs/{org}/events"],
+        listReceivedEventsForUser: ["GET /users/{username}/received_events"],
+        listReceivedPublicEventsForUser: [
+            "GET /users/{username}/received_events/public",
+        ],
+        listRepoEvents: ["GET /repos/{owner}/{repo}/events"],
+        listRepoNotificationsForAuthenticatedUser: [
+            "GET /repos/{owner}/{repo}/notifications",
+        ],
+        listReposStarredByAuthenticatedUser: ["GET /user/starred"],
+        listReposStarredByUser: ["GET /users/{username}/starred"],
+        listReposWatchedByUser: ["GET /users/{username}/subscriptions"],
+        listStargazersForRepo: ["GET /repos/{owner}/{repo}/stargazers"],
+        listWatchedReposForAuthenticatedUser: ["GET /user/subscriptions"],
+        listWatchersForRepo: ["GET /repos/{owner}/{repo}/subscribers"],
+        markNotificationsAsRead: ["PUT /notifications"],
+        markRepoNotificationsAsRead: ["PUT /repos/{owner}/{repo}/notifications"],
+        markThreadAsRead: ["PATCH /notifications/threads/{thread_id}"],
+        setRepoSubscription: ["PUT /repos/{owner}/{repo}/subscription"],
+        setThreadSubscription: [
+            "PUT /notifications/threads/{thread_id}/subscription",
+        ],
+        starRepoForAuthenticatedUser: ["PUT /user/starred/{owner}/{repo}"],
+        unstarRepoForAuthenticatedUser: ["DELETE /user/starred/{owner}/{repo}"],
+    },
+    apps: {
+        addRepoToInstallation: [
+            "PUT /user/installations/{installation_id}/repositories/{repository_id}",
+        ],
+        checkToken: ["POST /applications/{client_id}/token"],
+        createContentAttachment: [
+            "POST /content_references/{content_reference_id}/attachments",
+            { mediaType: { previews: ["corsair"] } },
+        ],
+        createFromManifest: ["POST /app-manifests/{code}/conversions"],
+        createInstallationAccessToken: [
+            "POST /app/installations/{installation_id}/access_tokens",
+        ],
+        deleteAuthorization: ["DELETE /applications/{client_id}/grant"],
+        deleteInstallation: ["DELETE /app/installations/{installation_id}"],
+        deleteToken: ["DELETE /applications/{client_id}/token"],
+        getAuthenticated: ["GET /app"],
+        getBySlug: ["GET /apps/{app_slug}"],
+        getInstallation: ["GET /app/installations/{installation_id}"],
+        getOrgInstallation: ["GET /orgs/{org}/installation"],
+        getRepoInstallation: ["GET /repos/{owner}/{repo}/installation"],
+        getSubscriptionPlanForAccount: [
+            "GET /marketplace_listing/accounts/{account_id}",
+        ],
+        getSubscriptionPlanForAccountStubbed: [
+            "GET /marketplace_listing/stubbed/accounts/{account_id}",
+        ],
+        getUserInstallation: ["GET /users/{username}/installation"],
+        getWebhookConfigForApp: ["GET /app/hook/config"],
+        listAccountsForPlan: ["GET /marketplace_listing/plans/{plan_id}/accounts"],
+        listAccountsForPlanStubbed: [
+            "GET /marketplace_listing/stubbed/plans/{plan_id}/accounts",
+        ],
+        listInstallationReposForAuthenticatedUser: [
+            "GET /user/installations/{installation_id}/repositories",
+        ],
+        listInstallations: ["GET /app/installations"],
+        listInstallationsForAuthenticatedUser: ["GET /user/installations"],
+        listPlans: ["GET /marketplace_listing/plans"],
+        listPlansStubbed: ["GET /marketplace_listing/stubbed/plans"],
+        listReposAccessibleToInstallation: ["GET /installation/repositories"],
+        listSubscriptionsForAuthenticatedUser: ["GET /user/marketplace_purchases"],
+        listSubscriptionsForAuthenticatedUserStubbed: [
+            "GET /user/marketplace_purchases/stubbed",
+        ],
+        removeRepoFromInstallation: [
+            "DELETE /user/installations/{installation_id}/repositories/{repository_id}",
+        ],
+        resetToken: ["PATCH /applications/{client_id}/token"],
+        revokeInstallationAccessToken: ["DELETE /installation/token"],
+        scopeToken: ["POST /applications/{client_id}/token/scoped"],
+        suspendInstallation: ["PUT /app/installations/{installation_id}/suspended"],
+        unsuspendInstallation: [
+            "DELETE /app/installations/{installation_id}/suspended",
+        ],
+        updateWebhookConfigForApp: ["PATCH /app/hook/config"],
+    },
+    billing: {
+        getGithubActionsBillingOrg: ["GET /orgs/{org}/settings/billing/actions"],
+        getGithubActionsBillingUser: [
+            "GET /users/{username}/settings/billing/actions",
+        ],
+        getGithubPackagesBillingOrg: ["GET /orgs/{org}/settings/billing/packages"],
+        getGithubPackagesBillingUser: [
+            "GET /users/{username}/settings/billing/packages",
+        ],
+        getSharedStorageBillingOrg: [
+            "GET /orgs/{org}/settings/billing/shared-storage",
+        ],
+        getSharedStorageBillingUser: [
+            "GET /users/{username}/settings/billing/shared-storage",
+        ],
+    },
+    checks: {
+        create: ["POST /repos/{owner}/{repo}/check-runs"],
+        createSuite: ["POST /repos/{owner}/{repo}/check-suites"],
+        get: ["GET /repos/{owner}/{repo}/check-runs/{check_run_id}"],
+        getSuite: ["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}"],
+        listAnnotations: [
+            "GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations",
+        ],
+        listForRef: ["GET /repos/{owner}/{repo}/commits/{ref}/check-runs"],
+        listForSuite: [
+            "GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs",
+        ],
+        listSuitesForRef: ["GET /repos/{owner}/{repo}/commits/{ref}/check-suites"],
+        rerequestSuite: [
+            "POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest",
+        ],
+        setSuitesPreferences: [
+            "PATCH /repos/{owner}/{repo}/check-suites/preferences",
+        ],
+        update: ["PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}"],
+    },
+    codeScanning: {
+        deleteAnalysis: [
+            "DELETE /repos/{owner}/{repo}/code-scanning/analyses/{analysis_id}{?confirm_delete}",
+        ],
+        getAlert: [
+            "GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}",
+            {},
+            { renamedParameters: { alert_id: "alert_number" } },
+        ],
+        getAnalysis: [
+            "GET /repos/{owner}/{repo}/code-scanning/analyses/{analysis_id}",
+        ],
+        getSarif: ["GET /repos/{owner}/{repo}/code-scanning/sarifs/{sarif_id}"],
+        listAlertsForRepo: ["GET /repos/{owner}/{repo}/code-scanning/alerts"],
+        listAlertsInstances: [
+            "GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/instances",
+        ],
+        listRecentAnalyses: ["GET /repos/{owner}/{repo}/code-scanning/analyses"],
+        updateAlert: [
+            "PATCH /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}",
+        ],
+        uploadSarif: ["POST /repos/{owner}/{repo}/code-scanning/sarifs"],
+    },
+    codesOfConduct: {
+        getAllCodesOfConduct: [
+            "GET /codes_of_conduct",
+            { mediaType: { previews: ["scarlet-witch"] } },
+        ],
+        getConductCode: [
+            "GET /codes_of_conduct/{key}",
+            { mediaType: { previews: ["scarlet-witch"] } },
+        ],
+        getForRepo: [
+            "GET /repos/{owner}/{repo}/community/code_of_conduct",
+            { mediaType: { previews: ["scarlet-witch"] } },
+        ],
+    },
+    emojis: { get: ["GET /emojis"] },
+    enterpriseAdmin: {
+        disableSelectedOrganizationGithubActionsEnterprise: [
+            "DELETE /enterprises/{enterprise}/actions/permissions/organizations/{org_id}",
+        ],
+        enableSelectedOrganizationGithubActionsEnterprise: [
+            "PUT /enterprises/{enterprise}/actions/permissions/organizations/{org_id}",
+        ],
+        getAllowedActionsEnterprise: [
+            "GET /enterprises/{enterprise}/actions/permissions/selected-actions",
+        ],
+        getGithubActionsPermissionsEnterprise: [
+            "GET /enterprises/{enterprise}/actions/permissions",
+        ],
+        listSelectedOrganizationsEnabledGithubActionsEnterprise: [
+            "GET /enterprises/{enterprise}/actions/permissions/organizations",
+        ],
+        setAllowedActionsEnterprise: [
+            "PUT /enterprises/{enterprise}/actions/permissions/selected-actions",
+        ],
+        setGithubActionsPermissionsEnterprise: [
+            "PUT /enterprises/{enterprise}/actions/permissions",
+        ],
+        setSelectedOrganizationsEnabledGithubActionsEnterprise: [
+            "PUT /enterprises/{enterprise}/actions/permissions/organizations",
+        ],
+    },
+    gists: {
+        checkIsStarred: ["GET /gists/{gist_id}/star"],
+        create: ["POST /gists"],
+        createComment: ["POST /gists/{gist_id}/comments"],
+        delete: ["DELETE /gists/{gist_id}"],
+        deleteComment: ["DELETE /gists/{gist_id}/comments/{comment_id}"],
+        fork: ["POST /gists/{gist_id}/forks"],
+        get: ["GET /gists/{gist_id}"],
+        getComment: ["GET /gists/{gist_id}/comments/{comment_id}"],
+        getRevision: ["GET /gists/{gist_id}/{sha}"],
+        list: ["GET /gists"],
+        listComments: ["GET /gists/{gist_id}/comments"],
+        listCommits: ["GET /gists/{gist_id}/commits"],
+        listForUser: ["GET /users/{username}/gists"],
+        listForks: ["GET /gists/{gist_id}/forks"],
+        listPublic: ["GET /gists/public"],
+        listStarred: ["GET /gists/starred"],
+        star: ["PUT /gists/{gist_id}/star"],
+        unstar: ["DELETE /gists/{gist_id}/star"],
+        update: ["PATCH /gists/{gist_id}"],
+        updateComment: ["PATCH /gists/{gist_id}/comments/{comment_id}"],
+    },
+    git: {
+        createBlob: ["POST /repos/{owner}/{repo}/git/blobs"],
+        createCommit: ["POST /repos/{owner}/{repo}/git/commits"],
+        createRef: ["POST /repos/{owner}/{repo}/git/refs"],
+        createTag: ["POST /repos/{owner}/{repo}/git/tags"],
+        createTree: ["POST /repos/{owner}/{repo}/git/trees"],
+        deleteRef: ["DELETE /repos/{owner}/{repo}/git/refs/{ref}"],
+        getBlob: ["GET /repos/{owner}/{repo}/git/blobs/{file_sha}"],
+        getCommit: ["GET /repos/{owner}/{repo}/git/commits/{commit_sha}"],
+        getRef: ["GET /repos/{owner}/{repo}/git/ref/{ref}"],
+        getTag: ["GET /repos/{owner}/{repo}/git/tags/{tag_sha}"],
+        getTree: ["GET /repos/{owner}/{repo}/git/trees/{tree_sha}"],
+        listMatchingRefs: ["GET /repos/{owner}/{repo}/git/matching-refs/{ref}"],
+        updateRef: ["PATCH /repos/{owner}/{repo}/git/refs/{ref}"],
+    },
+    gitignore: {
+        getAllTemplates: ["GET /gitignore/templates"],
+        getTemplate: ["GET /gitignore/templates/{name}"],
+    },
+    interactions: {
+        getRestrictionsForAuthenticatedUser: ["GET /user/interaction-limits"],
+        getRestrictionsForOrg: ["GET /orgs/{org}/interaction-limits"],
+        getRestrictionsForRepo: ["GET /repos/{owner}/{repo}/interaction-limits"],
+        getRestrictionsForYourPublicRepos: [
+            "GET /user/interaction-limits",
+            {},
+            { renamed: ["interactions", "getRestrictionsForAuthenticatedUser"] },
+        ],
+        removeRestrictionsForAuthenticatedUser: ["DELETE /user/interaction-limits"],
+        removeRestrictionsForOrg: ["DELETE /orgs/{org}/interaction-limits"],
+        removeRestrictionsForRepo: [
+            "DELETE /repos/{owner}/{repo}/interaction-limits",
+        ],
+        removeRestrictionsForYourPublicRepos: [
+            "DELETE /user/interaction-limits",
+            {},
+            { renamed: ["interactions", "removeRestrictionsForAuthenticatedUser"] },
+        ],
+        setRestrictionsForAuthenticatedUser: ["PUT /user/interaction-limits"],
+        setRestrictionsForOrg: ["PUT /orgs/{org}/interaction-limits"],
+        setRestrictionsForRepo: ["PUT /repos/{owner}/{repo}/interaction-limits"],
+        setRestrictionsForYourPublicRepos: [
+            "PUT /user/interaction-limits",
+            {},
+            { renamed: ["interactions", "setRestrictionsForAuthenticatedUser"] },
+        ],
+    },
+    issues: {
+        addAssignees: [
+            "POST /repos/{owner}/{repo}/issues/{issue_number}/assignees",
+        ],
+        addLabels: ["POST /repos/{owner}/{repo}/issues/{issue_number}/labels"],
+        checkUserCanBeAssigned: ["GET /repos/{owner}/{repo}/assignees/{assignee}"],
+        create: ["POST /repos/{owner}/{repo}/issues"],
+        createComment: [
+            "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+        ],
+        createLabel: ["POST /repos/{owner}/{repo}/labels"],
+        createMilestone: ["POST /repos/{owner}/{repo}/milestones"],
+        deleteComment: [
+            "DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}",
+        ],
+        deleteLabel: ["DELETE /repos/{owner}/{repo}/labels/{name}"],
+        deleteMilestone: [
+            "DELETE /repos/{owner}/{repo}/milestones/{milestone_number}",
+        ],
+        get: ["GET /repos/{owner}/{repo}/issues/{issue_number}"],
+        getComment: ["GET /repos/{owner}/{repo}/issues/comments/{comment_id}"],
+        getEvent: ["GET /repos/{owner}/{repo}/issues/events/{event_id}"],
+        getLabel: ["GET /repos/{owner}/{repo}/labels/{name}"],
+        getMilestone: ["GET /repos/{owner}/{repo}/milestones/{milestone_number}"],
+        list: ["GET /issues"],
+        listAssignees: ["GET /repos/{owner}/{repo}/assignees"],
+        listComments: ["GET /repos/{owner}/{repo}/issues/{issue_number}/comments"],
+        listCommentsForRepo: ["GET /repos/{owner}/{repo}/issues/comments"],
+        listEvents: ["GET /repos/{owner}/{repo}/issues/{issue_number}/events"],
+        listEventsForRepo: ["GET /repos/{owner}/{repo}/issues/events"],
+        listEventsForTimeline: [
+            "GET /repos/{owner}/{repo}/issues/{issue_number}/timeline",
+            { mediaType: { previews: ["mockingbird"] } },
+        ],
+        listForAuthenticatedUser: ["GET /user/issues"],
+        listForOrg: ["GET /orgs/{org}/issues"],
+        listForRepo: ["GET /repos/{owner}/{repo}/issues"],
+        listLabelsForMilestone: [
+            "GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels",
+        ],
+        listLabelsForRepo: ["GET /repos/{owner}/{repo}/labels"],
+        listLabelsOnIssue: [
+            "GET /repos/{owner}/{repo}/issues/{issue_number}/labels",
+        ],
+        listMilestones: ["GET /repos/{owner}/{repo}/milestones"],
+        lock: ["PUT /repos/{owner}/{repo}/issues/{issue_number}/lock"],
+        removeAllLabels: [
+            "DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels",
+        ],
+        removeAssignees: [
+            "DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees",
+        ],
+        removeLabel: [
+            "DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}",
+        ],
+        setLabels: ["PUT /repos/{owner}/{repo}/issues/{issue_number}/labels"],
+        unlock: ["DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock"],
+        update: ["PATCH /repos/{owner}/{repo}/issues/{issue_number}"],
+        updateComment: ["PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}"],
+        updateLabel: ["PATCH /repos/{owner}/{repo}/labels/{name}"],
+        updateMilestone: [
+            "PATCH /repos/{owner}/{repo}/milestones/{milestone_number}",
+        ],
+    },
+    licenses: {
+        get: ["GET /licenses/{license}"],
+        getAllCommonlyUsed: ["GET /licenses"],
+        getForRepo: ["GET /repos/{owner}/{repo}/license"],
+    },
+    markdown: {
+        render: ["POST /markdown"],
+        renderRaw: [
+            "POST /markdown/raw",
+            { headers: { "content-type": "text/plain; charset=utf-8" } },
+        ],
+    },
+    meta: {
+        get: ["GET /meta"],
+        getOctocat: ["GET /octocat"],
+        getZen: ["GET /zen"],
+        root: ["GET /"],
+    },
+    migrations: {
+        cancelImport: ["DELETE /repos/{owner}/{repo}/import"],
+        deleteArchiveForAuthenticatedUser: [
+            "DELETE /user/migrations/{migration_id}/archive",
+            { mediaType: { previews: ["wyandotte"] } },
+        ],
+        deleteArchiveForOrg: [
+            "DELETE /orgs/{org}/migrations/{migration_id}/archive",
+            { mediaType: { previews: ["wyandotte"] } },
+        ],
+        downloadArchiveForOrg: [
+            "GET /orgs/{org}/migrations/{migration_id}/archive",
+            { mediaType: { previews: ["wyandotte"] } },
+        ],
+        getArchiveForAuthenticatedUser: [
+            "GET /user/migrations/{migration_id}/archive",
+            { mediaType: { previews: ["wyandotte"] } },
+        ],
+        getCommitAuthors: ["GET /repos/{owner}/{repo}/import/authors"],
+        getImportStatus: ["GET /repos/{owner}/{repo}/import"],
+        getLargeFiles: ["GET /repos/{owner}/{repo}/import/large_files"],
+        getStatusForAuthenticatedUser: [
+            "GET /user/migrations/{migration_id}",
+            { mediaType: { previews: ["wyandotte"] } },
+        ],
+        getStatusForOrg: [
+            "GET /orgs/{org}/migrations/{migration_id}",
+            { mediaType: { previews: ["wyandotte"] } },
+        ],
+        listForAuthenticatedUser: [
+            "GET /user/migrations",
+            { mediaType: { previews: ["wyandotte"] } },
+        ],
+        listForOrg: [
+            "GET /orgs/{org}/migrations",
+            { mediaType: { previews: ["wyandotte"] } },
+        ],
+        listReposForOrg: [
+            "GET /orgs/{org}/migrations/{migration_id}/repositories",
+            { mediaType: { previews: ["wyandotte"] } },
+        ],
+        listReposForUser: [
+            "GET /user/migrations/{migration_id}/repositories",
+            { mediaType: { previews: ["wyandotte"] } },
+        ],
+        mapCommitAuthor: ["PATCH /repos/{owner}/{repo}/import/authors/{author_id}"],
+        setLfsPreference: ["PATCH /repos/{owner}/{repo}/import/lfs"],
+        startForAuthenticatedUser: ["POST /user/migrations"],
+        startForOrg: ["POST /orgs/{org}/migrations"],
+        startImport: ["PUT /repos/{owner}/{repo}/import"],
+        unlockRepoForAuthenticatedUser: [
+            "DELETE /user/migrations/{migration_id}/repos/{repo_name}/lock",
+            { mediaType: { previews: ["wyandotte"] } },
+        ],
+        unlockRepoForOrg: [
+            "DELETE /orgs/{org}/migrations/{migration_id}/repos/{repo_name}/lock",
+            { mediaType: { previews: ["wyandotte"] } },
+        ],
+        updateImport: ["PATCH /repos/{owner}/{repo}/import"],
+    },
+    orgs: {
+        blockUser: ["PUT /orgs/{org}/blocks/{username}"],
+        cancelInvitation: ["DELETE /orgs/{org}/invitations/{invitation_id}"],
+        checkBlockedUser: ["GET /orgs/{org}/blocks/{username}"],
+        checkMembershipForUser: ["GET /orgs/{org}/members/{username}"],
+        checkPublicMembershipForUser: ["GET /orgs/{org}/public_members/{username}"],
+        convertMemberToOutsideCollaborator: [
+            "PUT /orgs/{org}/outside_collaborators/{username}",
+        ],
+        createInvitation: ["POST /orgs/{org}/invitations"],
+        createWebhook: ["POST /orgs/{org}/hooks"],
+        deleteWebhook: ["DELETE /orgs/{org}/hooks/{hook_id}"],
+        get: ["GET /orgs/{org}"],
+        getMembershipForAuthenticatedUser: ["GET /user/memberships/orgs/{org}"],
+        getMembershipForUser: ["GET /orgs/{org}/memberships/{username}"],
+        getWebhook: ["GET /orgs/{org}/hooks/{hook_id}"],
+        getWebhookConfigForOrg: ["GET /orgs/{org}/hooks/{hook_id}/config"],
+        list: ["GET /organizations"],
+        listAppInstallations: ["GET /orgs/{org}/installations"],
+        listBlockedUsers: ["GET /orgs/{org}/blocks"],
+        listFailedInvitations: ["GET /orgs/{org}/failed_invitations"],
+        listForAuthenticatedUser: ["GET /user/orgs"],
+        listForUser: ["GET /users/{username}/orgs"],
+        listInvitationTeams: ["GET /orgs/{org}/invitations/{invitation_id}/teams"],
+        listMembers: ["GET /orgs/{org}/members"],
+        listMembershipsForAuthenticatedUser: ["GET /user/memberships/orgs"],
+        listOutsideCollaborators: ["GET /orgs/{org}/outside_collaborators"],
+        listPendingInvitations: ["GET /orgs/{org}/invitations"],
+        listPublicMembers: ["GET /orgs/{org}/public_members"],
+        listWebhooks: ["GET /orgs/{org}/hooks"],
+        pingWebhook: ["POST /orgs/{org}/hooks/{hook_id}/pings"],
+        removeMember: ["DELETE /orgs/{org}/members/{username}"],
+        removeMembershipForUser: ["DELETE /orgs/{org}/memberships/{username}"],
+        removeOutsideCollaborator: [
+            "DELETE /orgs/{org}/outside_collaborators/{username}",
+        ],
+        removePublicMembershipForAuthenticatedUser: [
+            "DELETE /orgs/{org}/public_members/{username}",
+        ],
+        setMembershipForUser: ["PUT /orgs/{org}/memberships/{username}"],
+        setPublicMembershipForAuthenticatedUser: [
+            "PUT /orgs/{org}/public_members/{username}",
+        ],
+        unblockUser: ["DELETE /orgs/{org}/blocks/{username}"],
+        update: ["PATCH /orgs/{org}"],
+        updateMembershipForAuthenticatedUser: [
+            "PATCH /user/memberships/orgs/{org}",
+        ],
+        updateWebhook: ["PATCH /orgs/{org}/hooks/{hook_id}"],
+        updateWebhookConfigForOrg: ["PATCH /orgs/{org}/hooks/{hook_id}/config"],
+    },
+    packages: {
+        deletePackageForAuthenticatedUser: [
+            "DELETE /user/packages/{package_type}/{package_name}",
+        ],
+        deletePackageForOrg: [
+            "DELETE /orgs/{org}/packages/{package_type}/{package_name}",
+        ],
+        deletePackageVersionForAuthenticatedUser: [
+            "DELETE /user/packages/{package_type}/{package_name}/versions/{package_version_id}",
+        ],
+        deletePackageVersionForOrg: [
+            "DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}",
+        ],
+        getAllPackageVersionsForAPackageOwnedByAnOrg: [
+            "GET /orgs/{org}/packages/{package_type}/{package_name}/versions",
+            {},
+            { renamed: ["packages", "getAllPackageVersionsForPackageOwnedByOrg"] },
+        ],
+        getAllPackageVersionsForAPackageOwnedByTheAuthenticatedUser: [
+            "GET /user/packages/{package_type}/{package_name}/versions",
+            {},
+            {
+                renamed: [
+                    "packages",
+                    "getAllPackageVersionsForPackageOwnedByAuthenticatedUser",
+                ],
+            },
+        ],
+        getAllPackageVersionsForPackageOwnedByAuthenticatedUser: [
+            "GET /user/packages/{package_type}/{package_name}/versions",
+        ],
+        getAllPackageVersionsForPackageOwnedByOrg: [
+            "GET /orgs/{org}/packages/{package_type}/{package_name}/versions",
+        ],
+        getAllPackageVersionsForPackageOwnedByUser: [
+            "GET /users/{username}/packages/{package_type}/{package_name}/versions",
+        ],
+        getPackageForAuthenticatedUser: [
+            "GET /user/packages/{package_type}/{package_name}",
+        ],
+        getPackageForOrganization: [
+            "GET /orgs/{org}/packages/{package_type}/{package_name}",
+        ],
+        getPackageForUser: [
+            "GET /users/{username}/packages/{package_type}/{package_name}",
+        ],
+        getPackageVersionForAuthenticatedUser: [
+            "GET /user/packages/{package_type}/{package_name}/versions/{package_version_id}",
+        ],
+        getPackageVersionForOrganization: [
+            "GET /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}",
+        ],
+        getPackageVersionForUser: [
+            "GET /users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}",
+        ],
+        restorePackageForAuthenticatedUser: [
+            "POST /user/packages/{package_type}/{package_name}/restore{?token}",
+        ],
+        restorePackageForOrg: [
+            "POST /orgs/{org}/packages/{package_type}/{package_name}/restore{?token}",
+        ],
+        restorePackageVersionForAuthenticatedUser: [
+            "POST /user/packages/{package_type}/{package_name}/versions/{package_version_id}/restore",
+        ],
+        restorePackageVersionForOrg: [
+            "POST /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore",
+        ],
+    },
+    projects: {
+        addCollaborator: [
+            "PUT /projects/{project_id}/collaborators/{username}",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        createCard: [
+            "POST /projects/columns/{column_id}/cards",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        createColumn: [
+            "POST /projects/{project_id}/columns",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        createForAuthenticatedUser: [
+            "POST /user/projects",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        createForOrg: [
+            "POST /orgs/{org}/projects",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        createForRepo: [
+            "POST /repos/{owner}/{repo}/projects",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        delete: [
+            "DELETE /projects/{project_id}",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        deleteCard: [
+            "DELETE /projects/columns/cards/{card_id}",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        deleteColumn: [
+            "DELETE /projects/columns/{column_id}",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        get: [
+            "GET /projects/{project_id}",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        getCard: [
+            "GET /projects/columns/cards/{card_id}",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        getColumn: [
+            "GET /projects/columns/{column_id}",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        getPermissionForUser: [
+            "GET /projects/{project_id}/collaborators/{username}/permission",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        listCards: [
+            "GET /projects/columns/{column_id}/cards",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        listCollaborators: [
+            "GET /projects/{project_id}/collaborators",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        listColumns: [
+            "GET /projects/{project_id}/columns",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        listForOrg: [
+            "GET /orgs/{org}/projects",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        listForRepo: [
+            "GET /repos/{owner}/{repo}/projects",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        listForUser: [
+            "GET /users/{username}/projects",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        moveCard: [
+            "POST /projects/columns/cards/{card_id}/moves",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        moveColumn: [
+            "POST /projects/columns/{column_id}/moves",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        removeCollaborator: [
+            "DELETE /projects/{project_id}/collaborators/{username}",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        update: [
+            "PATCH /projects/{project_id}",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        updateCard: [
+            "PATCH /projects/columns/cards/{card_id}",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        updateColumn: [
+            "PATCH /projects/columns/{column_id}",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+    },
+    pulls: {
+        checkIfMerged: ["GET /repos/{owner}/{repo}/pulls/{pull_number}/merge"],
+        create: ["POST /repos/{owner}/{repo}/pulls"],
+        createReplyForReviewComment: [
+            "POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies",
+        ],
+        createReview: ["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews"],
+        createReviewComment: [
+            "POST /repos/{owner}/{repo}/pulls/{pull_number}/comments",
+        ],
+        deletePendingReview: [
+            "DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}",
+        ],
+        deleteReviewComment: [
+            "DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}",
+        ],
+        dismissReview: [
+            "PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals",
+        ],
+        get: ["GET /repos/{owner}/{repo}/pulls/{pull_number}"],
+        getReview: [
+            "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}",
+        ],
+        getReviewComment: ["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}"],
+        list: ["GET /repos/{owner}/{repo}/pulls"],
+        listCommentsForReview: [
+            "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments",
+        ],
+        listCommits: ["GET /repos/{owner}/{repo}/pulls/{pull_number}/commits"],
+        listFiles: ["GET /repos/{owner}/{repo}/pulls/{pull_number}/files"],
+        listRequestedReviewers: [
+            "GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
+        ],
+        listReviewComments: [
+            "GET /repos/{owner}/{repo}/pulls/{pull_number}/comments",
+        ],
+        listReviewCommentsForRepo: ["GET /repos/{owner}/{repo}/pulls/comments"],
+        listReviews: ["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews"],
+        merge: ["PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge"],
+        removeRequestedReviewers: [
+            "DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
+        ],
+        requestReviewers: [
+            "POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
+        ],
+        submitReview: [
+            "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events",
+        ],
+        update: ["PATCH /repos/{owner}/{repo}/pulls/{pull_number}"],
+        updateBranch: [
+            "PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch",
+            { mediaType: { previews: ["lydian"] } },
+        ],
+        updateReview: [
+            "PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}",
+        ],
+        updateReviewComment: [
+            "PATCH /repos/{owner}/{repo}/pulls/comments/{comment_id}",
+        ],
+    },
+    rateLimit: { get: ["GET /rate_limit"] },
+    reactions: {
+        createForCommitComment: [
+            "POST /repos/{owner}/{repo}/comments/{comment_id}/reactions",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+        createForIssue: [
+            "POST /repos/{owner}/{repo}/issues/{issue_number}/reactions",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+        createForIssueComment: [
+            "POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+        createForPullRequestReviewComment: [
+            "POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+        createForTeamDiscussionCommentInOrg: [
+            "POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+        createForTeamDiscussionInOrg: [
+            "POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+        deleteForCommitComment: [
+            "DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+        deleteForIssue: [
+            "DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+        deleteForIssueComment: [
+            "DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+        deleteForPullRequestComment: [
+            "DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+        deleteForTeamDiscussion: [
+            "DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+        deleteForTeamDiscussionComment: [
+            "DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+        deleteLegacy: [
+            "DELETE /reactions/{reaction_id}",
+            { mediaType: { previews: ["squirrel-girl"] } },
+            {
+                deprecated: "octokit.reactions.deleteLegacy() is deprecated, see https://docs.github.com/rest/reference/reactions/#delete-a-reaction-legacy",
+            },
+        ],
+        listForCommitComment: [
+            "GET /repos/{owner}/{repo}/comments/{comment_id}/reactions",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+        listForIssue: [
+            "GET /repos/{owner}/{repo}/issues/{issue_number}/reactions",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+        listForIssueComment: [
+            "GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+        listForPullRequestReviewComment: [
+            "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+        listForTeamDiscussionCommentInOrg: [
+            "GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+        listForTeamDiscussionInOrg: [
+            "GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions",
+            { mediaType: { previews: ["squirrel-girl"] } },
+        ],
+    },
+    repos: {
+        acceptInvitation: ["PATCH /user/repository_invitations/{invitation_id}"],
+        addAppAccessRestrictions: [
+            "POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",
+            {},
+            { mapToData: "apps" },
+        ],
+        addCollaborator: ["PUT /repos/{owner}/{repo}/collaborators/{username}"],
+        addStatusCheckContexts: [
+            "POST /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts",
+            {},
+            { mapToData: "contexts" },
+        ],
+        addTeamAccessRestrictions: [
+            "POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",
+            {},
+            { mapToData: "teams" },
+        ],
+        addUserAccessRestrictions: [
+            "POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",
+            {},
+            { mapToData: "users" },
+        ],
+        checkCollaborator: ["GET /repos/{owner}/{repo}/collaborators/{username}"],
+        checkVulnerabilityAlerts: [
+            "GET /repos/{owner}/{repo}/vulnerability-alerts",
+            { mediaType: { previews: ["dorian"] } },
+        ],
+        compareCommits: ["GET /repos/{owner}/{repo}/compare/{base}...{head}"],
+        createCommitComment: [
+            "POST /repos/{owner}/{repo}/commits/{commit_sha}/comments",
+        ],
+        createCommitSignatureProtection: [
+            "POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures",
+            { mediaType: { previews: ["zzzax"] } },
+        ],
+        createCommitStatus: ["POST /repos/{owner}/{repo}/statuses/{sha}"],
+        createDeployKey: ["POST /repos/{owner}/{repo}/keys"],
+        createDeployment: ["POST /repos/{owner}/{repo}/deployments"],
+        createDeploymentStatus: [
+            "POST /repos/{owner}/{repo}/deployments/{deployment_id}/statuses",
+        ],
+        createDispatchEvent: ["POST /repos/{owner}/{repo}/dispatches"],
+        createForAuthenticatedUser: ["POST /user/repos"],
+        createFork: ["POST /repos/{owner}/{repo}/forks{?org,organization}"],
+        createInOrg: ["POST /orgs/{org}/repos"],
+        createOrUpdateEnvironment: [
+            "PUT /repos/{owner}/{repo}/environments/{environment_name}",
+        ],
+        createOrUpdateFileContents: ["PUT /repos/{owner}/{repo}/contents/{path}"],
+        createPagesSite: [
+            "POST /repos/{owner}/{repo}/pages",
+            { mediaType: { previews: ["switcheroo"] } },
+        ],
+        createRelease: ["POST /repos/{owner}/{repo}/releases"],
+        createUsingTemplate: [
+            "POST /repos/{template_owner}/{template_repo}/generate",
+            { mediaType: { previews: ["baptiste"] } },
+        ],
+        createWebhook: ["POST /repos/{owner}/{repo}/hooks"],
+        declineInvitation: ["DELETE /user/repository_invitations/{invitation_id}"],
+        delete: ["DELETE /repos/{owner}/{repo}"],
+        deleteAccessRestrictions: [
+            "DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions",
+        ],
+        deleteAdminBranchProtection: [
+            "DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins",
+        ],
+        deleteAnEnvironment: [
+            "DELETE /repos/{owner}/{repo}/environments/{environment_name}",
+        ],
+        deleteBranchProtection: [
+            "DELETE /repos/{owner}/{repo}/branches/{branch}/protection",
+        ],
+        deleteCommitComment: ["DELETE /repos/{owner}/{repo}/comments/{comment_id}"],
+        deleteCommitSignatureProtection: [
+            "DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures",
+            { mediaType: { previews: ["zzzax"] } },
+        ],
+        deleteDeployKey: ["DELETE /repos/{owner}/{repo}/keys/{key_id}"],
+        deleteDeployment: [
+            "DELETE /repos/{owner}/{repo}/deployments/{deployment_id}",
+        ],
+        deleteFile: ["DELETE /repos/{owner}/{repo}/contents/{path}"],
+        deleteInvitation: [
+            "DELETE /repos/{owner}/{repo}/invitations/{invitation_id}",
+        ],
+        deletePagesSite: [
+            "DELETE /repos/{owner}/{repo}/pages",
+            { mediaType: { previews: ["switcheroo"] } },
+        ],
+        deletePullRequestReviewProtection: [
+            "DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews",
+        ],
+        deleteRelease: ["DELETE /repos/{owner}/{repo}/releases/{release_id}"],
+        deleteReleaseAsset: [
+            "DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}",
+        ],
+        deleteWebhook: ["DELETE /repos/{owner}/{repo}/hooks/{hook_id}"],
+        disableAutomatedSecurityFixes: [
+            "DELETE /repos/{owner}/{repo}/automated-security-fixes",
+            { mediaType: { previews: ["london"] } },
+        ],
+        disableVulnerabilityAlerts: [
+            "DELETE /repos/{owner}/{repo}/vulnerability-alerts",
+            { mediaType: { previews: ["dorian"] } },
+        ],
+        downloadArchive: [
+            "GET /repos/{owner}/{repo}/zipball/{ref}",
+            {},
+            { renamed: ["repos", "downloadZipballArchive"] },
+        ],
+        downloadTarballArchive: ["GET /repos/{owner}/{repo}/tarball/{ref}"],
+        downloadZipballArchive: ["GET /repos/{owner}/{repo}/zipball/{ref}"],
+        enableAutomatedSecurityFixes: [
+            "PUT /repos/{owner}/{repo}/automated-security-fixes",
+            { mediaType: { previews: ["london"] } },
+        ],
+        enableVulnerabilityAlerts: [
+            "PUT /repos/{owner}/{repo}/vulnerability-alerts",
+            { mediaType: { previews: ["dorian"] } },
+        ],
+        get: ["GET /repos/{owner}/{repo}"],
+        getAccessRestrictions: [
+            "GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions",
+        ],
+        getAdminBranchProtection: [
+            "GET /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins",
+        ],
+        getAllEnvironments: ["GET /repos/{owner}/{repo}/environments"],
+        getAllStatusCheckContexts: [
+            "GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts",
+        ],
+        getAllTopics: [
+            "GET /repos/{owner}/{repo}/topics",
+            { mediaType: { previews: ["mercy"] } },
+        ],
+        getAppsWithAccessToProtectedBranch: [
+            "GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",
+        ],
+        getBranch: ["GET /repos/{owner}/{repo}/branches/{branch}"],
+        getBranchProtection: [
+            "GET /repos/{owner}/{repo}/branches/{branch}/protection",
+        ],
+        getClones: ["GET /repos/{owner}/{repo}/traffic/clones"],
+        getCodeFrequencyStats: ["GET /repos/{owner}/{repo}/stats/code_frequency"],
+        getCollaboratorPermissionLevel: [
+            "GET /repos/{owner}/{repo}/collaborators/{username}/permission",
+        ],
+        getCombinedStatusForRef: ["GET /repos/{owner}/{repo}/commits/{ref}/status"],
+        getCommit: ["GET /repos/{owner}/{repo}/commits/{ref}"],
+        getCommitActivityStats: ["GET /repos/{owner}/{repo}/stats/commit_activity"],
+        getCommitComment: ["GET /repos/{owner}/{repo}/comments/{comment_id}"],
+        getCommitSignatureProtection: [
+            "GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures",
+            { mediaType: { previews: ["zzzax"] } },
+        ],
+        getCommunityProfileMetrics: ["GET /repos/{owner}/{repo}/community/profile"],
+        getContent: ["GET /repos/{owner}/{repo}/contents/{path}"],
+        getContributorsStats: ["GET /repos/{owner}/{repo}/stats/contributors"],
+        getDeployKey: ["GET /repos/{owner}/{repo}/keys/{key_id}"],
+        getDeployment: ["GET /repos/{owner}/{repo}/deployments/{deployment_id}"],
+        getDeploymentStatus: [
+            "GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}",
+        ],
+        getEnvironment: [
+            "GET /repos/{owner}/{repo}/environments/{environment_name}",
+        ],
+        getLatestPagesBuild: ["GET /repos/{owner}/{repo}/pages/builds/latest"],
+        getLatestRelease: ["GET /repos/{owner}/{repo}/releases/latest"],
+        getPages: ["GET /repos/{owner}/{repo}/pages"],
+        getPagesBuild: ["GET /repos/{owner}/{repo}/pages/builds/{build_id}"],
+        getParticipationStats: ["GET /repos/{owner}/{repo}/stats/participation"],
+        getPullRequestReviewProtection: [
+            "GET /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews",
+        ],
+        getPunchCardStats: ["GET /repos/{owner}/{repo}/stats/punch_card"],
+        getReadme: ["GET /repos/{owner}/{repo}/readme"],
+        getReadmeInDirectory: ["GET /repos/{owner}/{repo}/readme/{dir}"],
+        getRelease: ["GET /repos/{owner}/{repo}/releases/{release_id}"],
+        getReleaseAsset: ["GET /repos/{owner}/{repo}/releases/assets/{asset_id}"],
+        getReleaseByTag: ["GET /repos/{owner}/{repo}/releases/tags/{tag}"],
+        getStatusChecksProtection: [
+            "GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",
+        ],
+        getTeamsWithAccessToProtectedBranch: [
+            "GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",
+        ],
+        getTopPaths: ["GET /repos/{owner}/{repo}/traffic/popular/paths"],
+        getTopReferrers: ["GET /repos/{owner}/{repo}/traffic/popular/referrers"],
+        getUsersWithAccessToProtectedBranch: [
+            "GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",
+        ],
+        getViews: ["GET /repos/{owner}/{repo}/traffic/views"],
+        getWebhook: ["GET /repos/{owner}/{repo}/hooks/{hook_id}"],
+        getWebhookConfigForRepo: [
+            "GET /repos/{owner}/{repo}/hooks/{hook_id}/config",
+        ],
+        listBranches: ["GET /repos/{owner}/{repo}/branches"],
+        listBranchesForHeadCommit: [
+            "GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head",
+            { mediaType: { previews: ["groot"] } },
+        ],
+        listCollaborators: ["GET /repos/{owner}/{repo}/collaborators"],
+        listCommentsForCommit: [
+            "GET /repos/{owner}/{repo}/commits/{commit_sha}/comments",
+        ],
+        listCommitCommentsForRepo: ["GET /repos/{owner}/{repo}/comments"],
+        listCommitStatusesForRef: [
+            "GET /repos/{owner}/{repo}/commits/{ref}/statuses",
+        ],
+        listCommits: ["GET /repos/{owner}/{repo}/commits"],
+        listContributors: ["GET /repos/{owner}/{repo}/contributors"],
+        listDeployKeys: ["GET /repos/{owner}/{repo}/keys"],
+        listDeploymentStatuses: [
+            "GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses",
+        ],
+        listDeployments: ["GET /repos/{owner}/{repo}/deployments"],
+        listForAuthenticatedUser: ["GET /user/repos"],
+        listForOrg: ["GET /orgs/{org}/repos"],
+        listForUser: ["GET /users/{username}/repos"],
+        listForks: ["GET /repos/{owner}/{repo}/forks"],
+        listInvitations: ["GET /repos/{owner}/{repo}/invitations"],
+        listInvitationsForAuthenticatedUser: ["GET /user/repository_invitations"],
+        listLanguages: ["GET /repos/{owner}/{repo}/languages"],
+        listPagesBuilds: ["GET /repos/{owner}/{repo}/pages/builds"],
+        listPublic: ["GET /repositories"],
+        listPullRequestsAssociatedWithCommit: [
+            "GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls",
+            { mediaType: { previews: ["groot"] } },
+        ],
+        listReleaseAssets: [
+            "GET /repos/{owner}/{repo}/releases/{release_id}/assets",
+        ],
+        listReleases: ["GET /repos/{owner}/{repo}/releases"],
+        listTags: ["GET /repos/{owner}/{repo}/tags"],
+        listTeams: ["GET /repos/{owner}/{repo}/teams"],
+        listWebhooks: ["GET /repos/{owner}/{repo}/hooks"],
+        merge: ["POST /repos/{owner}/{repo}/merges"],
+        pingWebhook: ["POST /repos/{owner}/{repo}/hooks/{hook_id}/pings"],
+        removeAppAccessRestrictions: [
+            "DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",
+            {},
+            { mapToData: "apps" },
+        ],
+        removeCollaborator: [
+            "DELETE /repos/{owner}/{repo}/collaborators/{username}",
+        ],
+        removeStatusCheckContexts: [
+            "DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts",
+            {},
+            { mapToData: "contexts" },
+        ],
+        removeStatusCheckProtection: [
+            "DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",
+        ],
+        removeTeamAccessRestrictions: [
+            "DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",
+            {},
+            { mapToData: "teams" },
+        ],
+        removeUserAccessRestrictions: [
+            "DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",
+            {},
+            { mapToData: "users" },
+        ],
+        renameBranch: ["POST /repos/{owner}/{repo}/branches/{branch}/rename"],
+        replaceAllTopics: [
+            "PUT /repos/{owner}/{repo}/topics",
+            { mediaType: { previews: ["mercy"] } },
+        ],
+        requestPagesBuild: ["POST /repos/{owner}/{repo}/pages/builds"],
+        setAdminBranchProtection: [
+            "POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins",
+        ],
+        setAppAccessRestrictions: [
+            "PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",
+            {},
+            { mapToData: "apps" },
+        ],
+        setStatusCheckContexts: [
+            "PUT /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts",
+            {},
+            { mapToData: "contexts" },
+        ],
+        setTeamAccessRestrictions: [
+            "PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",
+            {},
+            { mapToData: "teams" },
+        ],
+        setUserAccessRestrictions: [
+            "PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",
+            {},
+            { mapToData: "users" },
+        ],
+        testPushWebhook: ["POST /repos/{owner}/{repo}/hooks/{hook_id}/tests"],
+        transfer: ["POST /repos/{owner}/{repo}/transfer"],
+        update: ["PATCH /repos/{owner}/{repo}"],
+        updateBranchProtection: [
+            "PUT /repos/{owner}/{repo}/branches/{branch}/protection",
+        ],
+        updateCommitComment: ["PATCH /repos/{owner}/{repo}/comments/{comment_id}"],
+        updateInformationAboutPagesSite: ["PUT /repos/{owner}/{repo}/pages"],
+        updateInvitation: [
+            "PATCH /repos/{owner}/{repo}/invitations/{invitation_id}",
+        ],
+        updatePullRequestReviewProtection: [
+            "PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews",
+        ],
+        updateRelease: ["PATCH /repos/{owner}/{repo}/releases/{release_id}"],
+        updateReleaseAsset: [
+            "PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}",
+        ],
+        updateStatusCheckPotection: [
+            "PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",
+            {},
+            { renamed: ["repos", "updateStatusCheckProtection"] },
+        ],
+        updateStatusCheckProtection: [
+            "PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",
+        ],
+        updateWebhook: ["PATCH /repos/{owner}/{repo}/hooks/{hook_id}"],
+        updateWebhookConfigForRepo: [
+            "PATCH /repos/{owner}/{repo}/hooks/{hook_id}/config",
+        ],
+        uploadReleaseAsset: [
+            "POST /repos/{owner}/{repo}/releases/{release_id}/assets{?name,label}",
+            { baseUrl: "https://uploads.github.com" },
+        ],
+    },
+    search: {
+        code: ["GET /search/code"],
+        commits: ["GET /search/commits", { mediaType: { previews: ["cloak"] } }],
+        issuesAndPullRequests: ["GET /search/issues"],
+        labels: ["GET /search/labels"],
+        repos: ["GET /search/repositories"],
+        topics: ["GET /search/topics", { mediaType: { previews: ["mercy"] } }],
+        users: ["GET /search/users"],
+    },
+    secretScanning: {
+        getAlert: [
+            "GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}",
+        ],
+        listAlertsForRepo: ["GET /repos/{owner}/{repo}/secret-scanning/alerts"],
+        updateAlert: [
+            "PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}",
+        ],
+    },
+    teams: {
+        addOrUpdateMembershipForUserInOrg: [
+            "PUT /orgs/{org}/teams/{team_slug}/memberships/{username}",
+        ],
+        addOrUpdateProjectPermissionsInOrg: [
+            "PUT /orgs/{org}/teams/{team_slug}/projects/{project_id}",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        addOrUpdateRepoPermissionsInOrg: [
+            "PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}",
+        ],
+        checkPermissionsForProjectInOrg: [
+            "GET /orgs/{org}/teams/{team_slug}/projects/{project_id}",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        checkPermissionsForRepoInOrg: [
+            "GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}",
+        ],
+        create: ["POST /orgs/{org}/teams"],
+        createDiscussionCommentInOrg: [
+            "POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments",
+        ],
+        createDiscussionInOrg: ["POST /orgs/{org}/teams/{team_slug}/discussions"],
+        deleteDiscussionCommentInOrg: [
+            "DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}",
+        ],
+        deleteDiscussionInOrg: [
+            "DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}",
+        ],
+        deleteInOrg: ["DELETE /orgs/{org}/teams/{team_slug}"],
+        getByName: ["GET /orgs/{org}/teams/{team_slug}"],
+        getDiscussionCommentInOrg: [
+            "GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}",
+        ],
+        getDiscussionInOrg: [
+            "GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}",
+        ],
+        getMembershipForUserInOrg: [
+            "GET /orgs/{org}/teams/{team_slug}/memberships/{username}",
+        ],
+        list: ["GET /orgs/{org}/teams"],
+        listChildInOrg: ["GET /orgs/{org}/teams/{team_slug}/teams"],
+        listDiscussionCommentsInOrg: [
+            "GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments",
+        ],
+        listDiscussionsInOrg: ["GET /orgs/{org}/teams/{team_slug}/discussions"],
+        listForAuthenticatedUser: ["GET /user/teams"],
+        listMembersInOrg: ["GET /orgs/{org}/teams/{team_slug}/members"],
+        listPendingInvitationsInOrg: [
+            "GET /orgs/{org}/teams/{team_slug}/invitations",
+        ],
+        listProjectsInOrg: [
+            "GET /orgs/{org}/teams/{team_slug}/projects",
+            { mediaType: { previews: ["inertia"] } },
+        ],
+        listReposInOrg: ["GET /orgs/{org}/teams/{team_slug}/repos"],
+        removeMembershipForUserInOrg: [
+            "DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}",
+        ],
+        removeProjectInOrg: [
+            "DELETE /orgs/{org}/teams/{team_slug}/projects/{project_id}",
+        ],
+        removeRepoInOrg: [
+            "DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}",
+        ],
+        updateDiscussionCommentInOrg: [
+            "PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}",
+        ],
+        updateDiscussionInOrg: [
+            "PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}",
+        ],
+        updateInOrg: ["PATCH /orgs/{org}/teams/{team_slug}"],
+    },
+    users: {
+        addEmailForAuthenticated: ["POST /user/emails"],
+        block: ["PUT /user/blocks/{username}"],
+        checkBlocked: ["GET /user/blocks/{username}"],
+        checkFollowingForUser: ["GET /users/{username}/following/{target_user}"],
+        checkPersonIsFollowedByAuthenticated: ["GET /user/following/{username}"],
+        createGpgKeyForAuthenticated: ["POST /user/gpg_keys"],
+        createPublicSshKeyForAuthenticated: ["POST /user/keys"],
+        deleteEmailForAuthenticated: ["DELETE /user/emails"],
+        deleteGpgKeyForAuthenticated: ["DELETE /user/gpg_keys/{gpg_key_id}"],
+        deletePublicSshKeyForAuthenticated: ["DELETE /user/keys/{key_id}"],
+        follow: ["PUT /user/following/{username}"],
+        getAuthenticated: ["GET /user"],
+        getByUsername: ["GET /users/{username}"],
+        getContextForUser: ["GET /users/{username}/hovercard"],
+        getGpgKeyForAuthenticated: ["GET /user/gpg_keys/{gpg_key_id}"],
+        getPublicSshKeyForAuthenticated: ["GET /user/keys/{key_id}"],
+        list: ["GET /users"],
+        listBlockedByAuthenticated: ["GET /user/blocks"],
+        listEmailsForAuthenticated: ["GET /user/emails"],
+        listFollowedByAuthenticated: ["GET /user/following"],
+        listFollowersForAuthenticatedUser: ["GET /user/followers"],
+        listFollowersForUser: ["GET /users/{username}/followers"],
+        listFollowingForUser: ["GET /users/{username}/following"],
+        listGpgKeysForAuthenticated: ["GET /user/gpg_keys"],
+        listGpgKeysForUser: ["GET /users/{username}/gpg_keys"],
+        listPublicEmailsForAuthenticated: ["GET /user/public_emails"],
+        listPublicKeysForUser: ["GET /users/{username}/keys"],
+        listPublicSshKeysForAuthenticated: ["GET /user/keys"],
+        setPrimaryEmailVisibilityForAuthenticated: ["PATCH /user/email/visibility"],
+        unblock: ["DELETE /user/blocks/{username}"],
+        unfollow: ["DELETE /user/following/{username}"],
+        updateAuthenticated: ["PATCH /user"],
+    },
+};
+
+const VERSION$1 = "4.15.0";
+
+function endpointsToMethods(octokit, endpointsMap) {
+    const newMethods = {};
+    for (const [scope, endpoints] of Object.entries(endpointsMap)) {
+        for (const [methodName, endpoint] of Object.entries(endpoints)) {
+            const [route, defaults, decorations] = endpoint;
+            const [method, url] = route.split(/ /);
+            const endpointDefaults = Object.assign({ method, url }, defaults);
+            if (!newMethods[scope]) {
+                newMethods[scope] = {};
+            }
+            const scopeMethods = newMethods[scope];
+            if (decorations) {
+                scopeMethods[methodName] = decorate(octokit, scope, methodName, endpointDefaults, decorations);
+                continue;
+            }
+            scopeMethods[methodName] = octokit.request.defaults(endpointDefaults);
+        }
+    }
+    return newMethods;
+}
+function decorate(octokit, scope, methodName, defaults, decorations) {
+    const requestWithDefaults = octokit.request.defaults(defaults);
+    /* istanbul ignore next */
+    function withDecorations(...args) {
+        // @ts-ignore https://github.com/microsoft/TypeScript/issues/25488
+        let options = requestWithDefaults.endpoint.merge(...args);
+        // There are currently no other decorations than `.mapToData`
+        if (decorations.mapToData) {
+            options = Object.assign({}, options, {
+                data: options[decorations.mapToData],
+                [decorations.mapToData]: undefined,
+            });
+            return requestWithDefaults(options);
+        }
+        if (decorations.renamed) {
+            const [newScope, newMethodName] = decorations.renamed;
+            octokit.log.warn(`octokit.${scope}.${methodName}() has been renamed to octokit.${newScope}.${newMethodName}()`);
+        }
+        if (decorations.deprecated) {
+            octokit.log.warn(decorations.deprecated);
+        }
+        if (decorations.renamedParameters) {
+            // @ts-ignore https://github.com/microsoft/TypeScript/issues/25488
+            const options = requestWithDefaults.endpoint.merge(...args);
+            for (const [name, alias] of Object.entries(decorations.renamedParameters)) {
+                if (name in options) {
+                    octokit.log.warn(`"${name}" parameter is deprecated for "octokit.${scope}.${methodName}()". Use "${alias}" instead`);
+                    if (!(alias in options)) {
+                        options[alias] = options[name];
+                    }
+                    delete options[name];
+                }
+            }
+            return requestWithDefaults(options);
+        }
+        // @ts-ignore https://github.com/microsoft/TypeScript/issues/25488
+        return requestWithDefaults(...args);
+    }
+    return Object.assign(withDecorations, requestWithDefaults);
+}
+
+function restEndpointMethods(octokit) {
+    const api = endpointsToMethods(octokit, Endpoints);
+    return {
+        ...api,
+        rest: api,
+    };
+}
+restEndpointMethods.VERSION = VERSION$1;
+
+var distWeb$1 = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	restEndpointMethods: restEndpointMethods
+});
+
+const VERSION = "2.13.3";
+
+/**
+ * Some “list” response that can be paginated have a different response structure
+ *
+ * They have a `total_count` key in the response (search also has `incomplete_results`,
+ * /installation/repositories also has `repository_selection`), as well as a key with
+ * the list of the items which name varies from endpoint to endpoint.
+ *
+ * Octokit normalizes these responses so that paginated results are always returned following
+ * the same structure. One challenge is that if the list response has only one page, no Link
+ * header is provided, so this header alone is not sufficient to check wether a response is
+ * paginated or not.
+ *
+ * We check if a "total_count" key is present in the response data, but also make sure that
+ * a "url" property is not, as the "Get the combined status for a specific ref" endpoint would
+ * otherwise match: https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
+ */
+function normalizePaginatedListResponse(response) {
+    const responseNeedsNormalization = "total_count" in response.data && !("url" in response.data);
+    if (!responseNeedsNormalization)
+        return response;
+    // keep the additional properties intact as there is currently no other way
+    // to retrieve the same information.
+    const incompleteResults = response.data.incomplete_results;
+    const repositorySelection = response.data.repository_selection;
+    const totalCount = response.data.total_count;
+    delete response.data.incomplete_results;
+    delete response.data.repository_selection;
+    delete response.data.total_count;
+    const namespaceKey = Object.keys(response.data)[0];
+    const data = response.data[namespaceKey];
+    response.data = data;
+    if (typeof incompleteResults !== "undefined") {
+        response.data.incomplete_results = incompleteResults;
+    }
+    if (typeof repositorySelection !== "undefined") {
+        response.data.repository_selection = repositorySelection;
+    }
+    response.data.total_count = totalCount;
+    return response;
+}
+
+function iterator(octokit, route, parameters) {
+    const options = typeof route === "function"
+        ? route.endpoint(parameters)
+        : octokit.request.endpoint(route, parameters);
+    const requestMethod = typeof route === "function" ? route : octokit.request;
+    const method = options.method;
+    const headers = options.headers;
+    let url = options.url;
+    return {
+        [Symbol.asyncIterator]: () => ({
+            async next() {
+                if (!url)
+                    return { done: true };
+                const response = await requestMethod({ method, url, headers });
+                const normalizedResponse = normalizePaginatedListResponse(response);
+                // `response.headers.link` format:
+                // '<https://api.github.com/users/aseemk/followers?page=2>; rel="next", <https://api.github.com/users/aseemk/followers?page=2>; rel="last"'
+                // sets `url` to undefined if "next" URL is not present or `link` header is not set
+                url = ((normalizedResponse.headers.link || "").match(/<([^>]+)>;\s*rel="next"/) || [])[1];
+                return { value: normalizedResponse };
+            },
+        }),
+    };
+}
+
+function paginate(octokit, route, parameters, mapFn) {
+    if (typeof parameters === "function") {
+        mapFn = parameters;
+        parameters = undefined;
+    }
+    return gather(octokit, [], iterator(octokit, route, parameters)[Symbol.asyncIterator](), mapFn);
+}
+function gather(octokit, results, iterator, mapFn) {
+    return iterator.next().then((result) => {
+        if (result.done) {
+            return results;
+        }
+        let earlyExit = false;
+        function done() {
+            earlyExit = true;
+        }
+        results = results.concat(mapFn ? mapFn(result.value, done) : result.value.data);
+        if (earlyExit) {
+            return results;
+        }
+        return gather(octokit, results, iterator, mapFn);
+    });
+}
+
+const composePaginateRest = Object.assign(paginate, {
+    iterator,
+});
+
+const paginatingEndpoints = [
+    "GET /app/installations",
+    "GET /applications/grants",
+    "GET /authorizations",
+    "GET /enterprises/{enterprise}/actions/permissions/organizations",
+    "GET /enterprises/{enterprise}/actions/runner-groups",
+    "GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations",
+    "GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners",
+    "GET /enterprises/{enterprise}/actions/runners",
+    "GET /enterprises/{enterprise}/actions/runners/downloads",
+    "GET /events",
+    "GET /gists",
+    "GET /gists/public",
+    "GET /gists/starred",
+    "GET /gists/{gist_id}/comments",
+    "GET /gists/{gist_id}/commits",
+    "GET /gists/{gist_id}/forks",
+    "GET /installation/repositories",
+    "GET /issues",
+    "GET /marketplace_listing/plans",
+    "GET /marketplace_listing/plans/{plan_id}/accounts",
+    "GET /marketplace_listing/stubbed/plans",
+    "GET /marketplace_listing/stubbed/plans/{plan_id}/accounts",
+    "GET /networks/{owner}/{repo}/events",
+    "GET /notifications",
+    "GET /organizations",
+    "GET /orgs/{org}/actions/permissions/repositories",
+    "GET /orgs/{org}/actions/runner-groups",
+    "GET /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories",
+    "GET /orgs/{org}/actions/runner-groups/{runner_group_id}/runners",
+    "GET /orgs/{org}/actions/runners",
+    "GET /orgs/{org}/actions/runners/downloads",
+    "GET /orgs/{org}/actions/secrets",
+    "GET /orgs/{org}/actions/secrets/{secret_name}/repositories",
+    "GET /orgs/{org}/blocks",
+    "GET /orgs/{org}/credential-authorizations",
+    "GET /orgs/{org}/events",
+    "GET /orgs/{org}/failed_invitations",
+    "GET /orgs/{org}/hooks",
+    "GET /orgs/{org}/installations",
+    "GET /orgs/{org}/invitations",
+    "GET /orgs/{org}/invitations/{invitation_id}/teams",
+    "GET /orgs/{org}/issues",
+    "GET /orgs/{org}/members",
+    "GET /orgs/{org}/migrations",
+    "GET /orgs/{org}/migrations/{migration_id}/repositories",
+    "GET /orgs/{org}/outside_collaborators",
+    "GET /orgs/{org}/projects",
+    "GET /orgs/{org}/public_members",
+    "GET /orgs/{org}/repos",
+    "GET /orgs/{org}/team-sync/groups",
+    "GET /orgs/{org}/teams",
+    "GET /orgs/{org}/teams/{team_slug}/discussions",
+    "GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments",
+    "GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions",
+    "GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions",
+    "GET /orgs/{org}/teams/{team_slug}/invitations",
+    "GET /orgs/{org}/teams/{team_slug}/members",
+    "GET /orgs/{org}/teams/{team_slug}/projects",
+    "GET /orgs/{org}/teams/{team_slug}/repos",
+    "GET /orgs/{org}/teams/{team_slug}/team-sync/group-mappings",
+    "GET /orgs/{org}/teams/{team_slug}/teams",
+    "GET /projects/columns/{column_id}/cards",
+    "GET /projects/{project_id}/collaborators",
+    "GET /projects/{project_id}/columns",
+    "GET /repos/{owner}/{repo}/actions/artifacts",
+    "GET /repos/{owner}/{repo}/actions/runners",
+    "GET /repos/{owner}/{repo}/actions/runners/downloads",
+    "GET /repos/{owner}/{repo}/actions/runs",
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts",
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
+    "GET /repos/{owner}/{repo}/actions/secrets",
+    "GET /repos/{owner}/{repo}/actions/workflows",
+    "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",
+    "GET /repos/{owner}/{repo}/assignees",
+    "GET /repos/{owner}/{repo}/branches",
+    "GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations",
+    "GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs",
+    "GET /repos/{owner}/{repo}/code-scanning/alerts",
+    "GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/instances",
+    "GET /repos/{owner}/{repo}/code-scanning/analyses",
+    "GET /repos/{owner}/{repo}/collaborators",
+    "GET /repos/{owner}/{repo}/comments",
+    "GET /repos/{owner}/{repo}/comments/{comment_id}/reactions",
+    "GET /repos/{owner}/{repo}/commits",
+    "GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head",
+    "GET /repos/{owner}/{repo}/commits/{commit_sha}/comments",
+    "GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls",
+    "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+    "GET /repos/{owner}/{repo}/commits/{ref}/check-suites",
+    "GET /repos/{owner}/{repo}/commits/{ref}/statuses",
+    "GET /repos/{owner}/{repo}/contributors",
+    "GET /repos/{owner}/{repo}/deployments",
+    "GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses",
+    "GET /repos/{owner}/{repo}/events",
+    "GET /repos/{owner}/{repo}/forks",
+    "GET /repos/{owner}/{repo}/git/matching-refs/{ref}",
+    "GET /repos/{owner}/{repo}/hooks",
+    "GET /repos/{owner}/{repo}/invitations",
+    "GET /repos/{owner}/{repo}/issues",
+    "GET /repos/{owner}/{repo}/issues/comments",
+    "GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
+    "GET /repos/{owner}/{repo}/issues/events",
+    "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
+    "GET /repos/{owner}/{repo}/issues/{issue_number}/events",
+    "GET /repos/{owner}/{repo}/issues/{issue_number}/labels",
+    "GET /repos/{owner}/{repo}/issues/{issue_number}/reactions",
+    "GET /repos/{owner}/{repo}/issues/{issue_number}/timeline",
+    "GET /repos/{owner}/{repo}/keys",
+    "GET /repos/{owner}/{repo}/labels",
+    "GET /repos/{owner}/{repo}/milestones",
+    "GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels",
+    "GET /repos/{owner}/{repo}/notifications",
+    "GET /repos/{owner}/{repo}/pages/builds",
+    "GET /repos/{owner}/{repo}/projects",
+    "GET /repos/{owner}/{repo}/pulls",
+    "GET /repos/{owner}/{repo}/pulls/comments",
+    "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
+    "GET /repos/{owner}/{repo}/pulls/{pull_number}/comments",
+    "GET /repos/{owner}/{repo}/pulls/{pull_number}/commits",
+    "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
+    "GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
+    "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+    "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments",
+    "GET /repos/{owner}/{repo}/releases",
+    "GET /repos/{owner}/{repo}/releases/{release_id}/assets",
+    "GET /repos/{owner}/{repo}/secret-scanning/alerts",
+    "GET /repos/{owner}/{repo}/stargazers",
+    "GET /repos/{owner}/{repo}/subscribers",
+    "GET /repos/{owner}/{repo}/tags",
+    "GET /repos/{owner}/{repo}/teams",
+    "GET /repositories",
+    "GET /repositories/{repository_id}/environments/{environment_name}/secrets",
+    "GET /scim/v2/enterprises/{enterprise}/Groups",
+    "GET /scim/v2/enterprises/{enterprise}/Users",
+    "GET /scim/v2/organizations/{org}/Users",
+    "GET /search/code",
+    "GET /search/commits",
+    "GET /search/issues",
+    "GET /search/labels",
+    "GET /search/repositories",
+    "GET /search/topics",
+    "GET /search/users",
+    "GET /teams/{team_id}/discussions",
+    "GET /teams/{team_id}/discussions/{discussion_number}/comments",
+    "GET /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions",
+    "GET /teams/{team_id}/discussions/{discussion_number}/reactions",
+    "GET /teams/{team_id}/invitations",
+    "GET /teams/{team_id}/members",
+    "GET /teams/{team_id}/projects",
+    "GET /teams/{team_id}/repos",
+    "GET /teams/{team_id}/team-sync/group-mappings",
+    "GET /teams/{team_id}/teams",
+    "GET /user/blocks",
+    "GET /user/emails",
+    "GET /user/followers",
+    "GET /user/following",
+    "GET /user/gpg_keys",
+    "GET /user/installations",
+    "GET /user/installations/{installation_id}/repositories",
+    "GET /user/issues",
+    "GET /user/keys",
+    "GET /user/marketplace_purchases",
+    "GET /user/marketplace_purchases/stubbed",
+    "GET /user/memberships/orgs",
+    "GET /user/migrations",
+    "GET /user/migrations/{migration_id}/repositories",
+    "GET /user/orgs",
+    "GET /user/public_emails",
+    "GET /user/repos",
+    "GET /user/repository_invitations",
+    "GET /user/starred",
+    "GET /user/subscriptions",
+    "GET /user/teams",
+    "GET /users",
+    "GET /users/{username}/events",
+    "GET /users/{username}/events/orgs/{org}",
+    "GET /users/{username}/events/public",
+    "GET /users/{username}/followers",
+    "GET /users/{username}/following",
+    "GET /users/{username}/gists",
+    "GET /users/{username}/gpg_keys",
+    "GET /users/{username}/keys",
+    "GET /users/{username}/orgs",
+    "GET /users/{username}/projects",
+    "GET /users/{username}/received_events",
+    "GET /users/{username}/received_events/public",
+    "GET /users/{username}/repos",
+    "GET /users/{username}/starred",
+    "GET /users/{username}/subscriptions",
+];
+
+function isPaginatingEndpoint(arg) {
+    if (typeof arg === "string") {
+        return paginatingEndpoints.includes(arg);
+    }
+    else {
+        return false;
+    }
+}
+
+/**
+ * @param octokit Octokit instance
+ * @param options Options passed to Octokit constructor
+ */
+function paginateRest(octokit) {
+    return {
+        paginate: Object.assign(paginate.bind(null, octokit), {
+            iterator: iterator.bind(null, octokit),
+        }),
+    };
+}
+paginateRest.VERSION = VERSION;
+
+var distWeb = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	composePaginateRest: composePaginateRest,
+	isPaginatingEndpoint: isPaginatingEndpoint,
+	paginateRest: paginateRest,
+	paginatingEndpoints: paginatingEndpoints
+});
+
+var core_1 = /*@__PURE__*/getAugmentedNamespace(distWeb$2);
+
+var plugin_rest_endpoint_methods_1 = /*@__PURE__*/getAugmentedNamespace(distWeb$1);
+
+var plugin_paginate_rest_1 = /*@__PURE__*/getAugmentedNamespace(distWeb);
+
+var utils$1 = createCommonjsModule(function (module, exports) {
+var __createBinding = (commonjsGlobal && commonjsGlobal.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (commonjsGlobal && commonjsGlobal.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (commonjsGlobal && commonjsGlobal.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getOctokitOptions = exports.GitHub = exports.context = void 0;
+const Context = __importStar(context);
+const Utils = __importStar(utils$2);
+// octokit + plugins
+
+
+
+exports.context = new Context.Context();
+const baseUrl = Utils.getApiBaseUrl();
+const defaults = {
+    baseUrl,
+    request: {
+        agent: Utils.getProxyAgent(baseUrl)
+    }
+};
+exports.GitHub = core_1.Octokit.plugin(plugin_rest_endpoint_methods_1.restEndpointMethods, plugin_paginate_rest_1.paginateRest).defaults(defaults);
+/**
+ * Convience function to correctly format Octokit Options to pass into the constructor.
+ *
+ * @param     token    the repo PAT or GITHUB_TOKEN
+ * @param     options  other options to set
+ */
+function getOctokitOptions(token, options) {
+    const opts = Object.assign({}, options || {}); // Shallow clone - don't mutate the object provided by the caller
+    // Auth
+    const auth = Utils.getAuthString(token, opts);
+    if (auth) {
+        opts.auth = auth;
+    }
+    return opts;
+}
+exports.getOctokitOptions = getOctokitOptions;
+//# sourceMappingURL=utils.js.map
+});
+
+var github = createCommonjsModule(function (module, exports) {
+var __createBinding = (commonjsGlobal && commonjsGlobal.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (commonjsGlobal && commonjsGlobal.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (commonjsGlobal && commonjsGlobal.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getOctokit = exports.context = void 0;
+const Context = __importStar(context);
+
+exports.context = new Context.Context();
+/**
+ * Returns a hydrated octokit ready to use for GitHub Actions
+ *
+ * @param     token    the repo PAT or GITHUB_TOKEN
+ * @param     options  other options to set
+ */
+function getOctokit(token, options) {
+    return new utils$1.GitHub(utils$1.getOctokitOptions(token, options));
+}
+exports.getOctokit = getOctokit;
+//# sourceMappingURL=github.js.map
+});
+
+var github$1 = /*@__PURE__*/getDefaultExportFromCjs(github);
+
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Sanitizes an input into a string so it can be passed into issueCommand safely
+ * @param input input to sanitize into a string
+ */
+function toCommandValue(input) {
+    if (input === null || input === undefined) {
+        return '';
+    }
+    else if (typeof input === 'string' || input instanceof String) {
+        return input;
+    }
+    return JSON.stringify(input);
+}
+var toCommandValue_1 = toCommandValue;
+
+
+var utils = /*#__PURE__*/Object.defineProperty({
+	toCommandValue: toCommandValue_1
+}, '__esModule', {value: true});
+
+var __importStar$1 = (commonjsGlobal && commonjsGlobal.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+
+const os$1 = __importStar$1(require$$0__default['default']);
+
+/**
+ * Commands
+ *
+ * Command Format:
+ *   ::name key=value,key=value::message
+ *
+ * Examples:
+ *   ::warning::This is the message
+ *   ::set-env name=MY_VAR::some value
+ */
+function issueCommand$1(command, properties, message) {
+    const cmd = new Command(command, properties, message);
+    process.stdout.write(cmd.toString() + os$1.EOL);
+}
+var issueCommand_1$1 = issueCommand$1;
+function issue(name, message = '') {
+    issueCommand$1(name, {}, message);
+}
+var issue_1 = issue;
+const CMD_STRING = '::';
+class Command {
+    constructor(command, properties, message) {
+        if (!command) {
+            command = 'missing.command';
+        }
+        this.command = command;
+        this.properties = properties;
+        this.message = message;
+    }
+    toString() {
+        let cmdStr = CMD_STRING + this.command;
+        if (this.properties && Object.keys(this.properties).length > 0) {
+            cmdStr += ' ';
+            let first = true;
+            for (const key in this.properties) {
+                if (this.properties.hasOwnProperty(key)) {
+                    const val = this.properties[key];
+                    if (val) {
+                        if (first) {
+                            first = false;
+                        }
+                        else {
+                            cmdStr += ',';
+                        }
+                        cmdStr += `${key}=${escapeProperty(val)}`;
+                    }
+                }
+            }
+        }
+        cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
+        return cmdStr;
+    }
+}
+function escapeData(s) {
+    return utils.toCommandValue(s)
+        .replace(/%/g, '%25')
+        .replace(/\r/g, '%0D')
+        .replace(/\n/g, '%0A');
+}
+function escapeProperty(s) {
+    return utils.toCommandValue(s)
+        .replace(/%/g, '%25')
+        .replace(/\r/g, '%0D')
+        .replace(/\n/g, '%0A')
+        .replace(/:/g, '%3A')
+        .replace(/,/g, '%2C');
+}
+
+
+var command = /*#__PURE__*/Object.defineProperty({
+	issueCommand: issueCommand_1$1,
+	issue: issue_1
+}, '__esModule', {value: true});
+
+// For internal use, subject to change.
+var __importStar = (commonjsGlobal && commonjsGlobal.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const fs = __importStar(fs_1__default['default']);
+const os = __importStar(require$$0__default['default']);
+
+function issueCommand(command, message) {
+    const filePath = process.env[`GITHUB_${command}`];
+    if (!filePath) {
+        throw new Error(`Unable to find environment variable for file command ${command}`);
+    }
+    if (!fs.existsSync(filePath)) {
+        throw new Error(`Missing file at path: ${filePath}`);
+    }
+    fs.appendFileSync(filePath, `${utils.toCommandValue(message)}${os.EOL}`, {
+        encoding: 'utf8'
+    });
+}
+var issueCommand_1 = issueCommand;
+
+
+var fileCommand = /*#__PURE__*/Object.defineProperty({
+	issueCommand: issueCommand_1
+}, '__esModule', {value: true});
+
+var core = createCommonjsModule(function (module, exports) {
+var __awaiter = (commonjsGlobal && commonjsGlobal.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importStar = (commonjsGlobal && commonjsGlobal.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+
+
+
+const os = __importStar(require$$0__default['default']);
+const path = __importStar(require$$1__default['default']);
+/**
+ * The code to exit an action
+ */
+var ExitCode;
+(function (ExitCode) {
+    /**
+     * A code indicating that the action was successful
+     */
+    ExitCode[ExitCode["Success"] = 0] = "Success";
+    /**
+     * A code indicating that the action was a failure
+     */
+    ExitCode[ExitCode["Failure"] = 1] = "Failure";
+})(ExitCode = exports.ExitCode || (exports.ExitCode = {}));
+//-----------------------------------------------------------------------
+// Variables
+//-----------------------------------------------------------------------
+/**
+ * Sets env variable for this action and future actions in the job
+ * @param name the name of the variable to set
+ * @param val the value of the variable. Non-string values will be converted to a string via JSON.stringify
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function exportVariable(name, val) {
+    const convertedVal = utils.toCommandValue(val);
+    process.env[name] = convertedVal;
+    const filePath = process.env['GITHUB_ENV'] || '';
+    if (filePath) {
+        const delimiter = '_GitHubActionsFileCommandDelimeter_';
+        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
+        fileCommand.issueCommand('ENV', commandValue);
+    }
+    else {
+        command.issueCommand('set-env', { name }, convertedVal);
+    }
+}
+exports.exportVariable = exportVariable;
+/**
+ * Registers a secret which will get masked from logs
+ * @param secret value of the secret
+ */
+function setSecret(secret) {
+    command.issueCommand('add-mask', {}, secret);
+}
+exports.setSecret = setSecret;
+/**
+ * Prepends inputPath to the PATH (for this action and future actions)
+ * @param inputPath
+ */
+function addPath(inputPath) {
+    const filePath = process.env['GITHUB_PATH'] || '';
+    if (filePath) {
+        fileCommand.issueCommand('PATH', inputPath);
+    }
+    else {
+        command.issueCommand('add-path', {}, inputPath);
+    }
+    process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
+}
+exports.addPath = addPath;
+/**
+ * Gets the value of an input.  The value is also trimmed.
+ *
+ * @param     name     name of the input to get
+ * @param     options  optional. See InputOptions.
+ * @returns   string
+ */
+function getInput(name, options) {
+    const val = process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || '';
+    if (options && options.required && !val) {
+        throw new Error(`Input required and not supplied: ${name}`);
+    }
+    return val.trim();
+}
+exports.getInput = getInput;
+/**
+ * Sets the value of an output.
+ *
+ * @param     name     name of the output to set
+ * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setOutput(name, value) {
+    command.issueCommand('set-output', { name }, value);
+}
+exports.setOutput = setOutput;
+/**
+ * Enables or disables the echoing of commands into stdout for the rest of the step.
+ * Echoing is disabled by default if ACTIONS_STEP_DEBUG is not set.
+ *
+ */
+function setCommandEcho(enabled) {
+    command.issue('echo', enabled ? 'on' : 'off');
+}
+exports.setCommandEcho = setCommandEcho;
+//-----------------------------------------------------------------------
+// Results
+//-----------------------------------------------------------------------
+/**
+ * Sets the action status to failed.
+ * When the action exits it will be with an exit code of 1
+ * @param message add error issue message
+ */
+function setFailed(message) {
+    process.exitCode = ExitCode.Failure;
+    error(message);
+}
+exports.setFailed = setFailed;
+//-----------------------------------------------------------------------
+// Logging Commands
+//-----------------------------------------------------------------------
+/**
+ * Gets whether Actions Step Debug is on or not
+ */
+function isDebug() {
+    return process.env['RUNNER_DEBUG'] === '1';
+}
+exports.isDebug = isDebug;
+/**
+ * Writes debug message to user log
+ * @param message debug message
+ */
+function debug(message) {
+    command.issueCommand('debug', {}, message);
+}
+exports.debug = debug;
+/**
+ * Adds an error issue
+ * @param message error issue message. Errors will be converted to string via toString()
+ */
+function error(message) {
+    command.issue('error', message instanceof Error ? message.toString() : message);
+}
+exports.error = error;
+/**
+ * Adds an warning issue
+ * @param message warning issue message. Errors will be converted to string via toString()
+ */
+function warning(message) {
+    command.issue('warning', message instanceof Error ? message.toString() : message);
+}
+exports.warning = warning;
+/**
+ * Writes info to log with console.log.
+ * @param message info message
+ */
+function info(message) {
+    process.stdout.write(message + os.EOL);
+}
+exports.info = info;
+/**
+ * Begin an output group.
+ *
+ * Output until the next `groupEnd` will be foldable in this group
+ *
+ * @param name The name of the output group
+ */
+function startGroup(name) {
+    command.issue('group', name);
+}
+exports.startGroup = startGroup;
+/**
+ * End an output group.
+ */
+function endGroup() {
+    command.issue('endgroup');
+}
+exports.endGroup = endGroup;
+/**
+ * Wrap an asynchronous function call in a group.
+ *
+ * Returns the same type as the function itself.
+ *
+ * @param name The name of the group
+ * @param fn The function to wrap in the group
+ */
+function group(name, fn) {
+    return __awaiter(this, void 0, void 0, function* () {
+        startGroup(name);
+        let result;
+        try {
+            result = yield fn();
+        }
+        finally {
+            endGroup();
+        }
+        return result;
+    });
+}
+exports.group = group;
+//-----------------------------------------------------------------------
+// Wrapper action state
+//-----------------------------------------------------------------------
+/**
+ * Saves state for current action, the state can only be retrieved by this action's post job execution.
+ *
+ * @param     name     name of the state to store
+ * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function saveState(name, value) {
+    command.issueCommand('save-state', { name }, value);
+}
+exports.saveState = saveState;
+/**
+ * Gets the value of an state set by this action's main execution.
+ *
+ * @param     name     name of the state to get
+ * @returns   string
+ */
+function getState(name) {
+    return process.env[`STATE_${name}`] || '';
+}
+exports.getState = getState;
+//# sourceMappingURL=core.js.map
+});
+
+var core$1 = /*@__PURE__*/getDefaultExportFromCjs(core);
+
+let _octokit = null;
+function getCommit() {
+  return {
+    commit: github$1.context.sha
+  };
+}
+function getRepository() {
+  return github$1.context.repo;
+}
+function getInput(name, required = true) {
+  return core$1.getInput(name, {
+    required
+  });
+}
+function setOutput(name, value) {
+  core$1.setOutput(name, value);
+}
+function setFailed(message) {
+  core$1.setFailed(message);
+}
+function getOctokit() {
+  if (_octokit === null) {
+    const githubToken = getInput('github-token');
+    _octokit = github$1.getOctokit(githubToken);
+  }
+
+  return _octokit;
+}
+
+const TAG_LIST_QUERY = `query tagList($owner: String!, $repo: String!, $query: String!) {
+  repository(owner: $owner, name: $repo) {
+    refs(
+      refPrefix: "refs/tags/",
+      orderBy: { field: TAG_COMMIT_DATE, direction:DESC },
+      first: 20,
+      query: $query
+    ) {
+      nodes {
+        name
+      }
+    }
+  }
+}`;
+function getTagList(options) {
+  const {
+    repository,
+    tagPrefix
+  } = options;
+  const variables = {
+    owner: repository.owner,
+    repo: repository.repo,
+    query: tagPrefix
+  };
+  return getOctokit().graphql(TAG_LIST_QUERY, {
+    variables
+  }).then(({
+    tagList
+  }) => {
+    return tagList.repository.refs.nodes.map(node => ({
+      tag: node.name
+    }));
+  });
+}
+
+function compareTag(options) {
+  const {
+    tag,
+    commit,
+    repository
+  } = options;
+  const params = { ...repository,
+    base: tag.tag,
+    head: commit.commit
+  };
+  const octokit = getOctokit();
+  return octokit.repos.compareCommits(params).then(response => {
+    const {
+      status,
+      ahead_by: distance
+    } = response.data;
+    const isAnscestor = status === 'ahead' || status === 'identical';
+    return isAnscestor ? { ...tag,
+      distance
+    } : null;
+  });
+}
+
+// Note: this is the semver.org version of the spec that it implements
+// Not necessarily the package version of this code.
+const SEMVER_SPEC_VERSION = '2.0.0';
+
+const MAX_LENGTH$2 = 256;
+const MAX_SAFE_INTEGER$1 = Number.MAX_SAFE_INTEGER ||
+  /* istanbul ignore next */ 9007199254740991;
+
+// Max safe segment length for coercion.
+const MAX_SAFE_COMPONENT_LENGTH = 16;
+
+var constants = {
+  SEMVER_SPEC_VERSION,
+  MAX_LENGTH: MAX_LENGTH$2,
+  MAX_SAFE_INTEGER: MAX_SAFE_INTEGER$1,
+  MAX_SAFE_COMPONENT_LENGTH
+};
+
+const debug = (
+  typeof process === 'object' &&
+  process.env &&
+  process.env.NODE_DEBUG &&
+  /\bsemver\b/i.test(process.env.NODE_DEBUG)
+) ? (...args) => console.error('SEMVER', ...args)
+  : () => {};
+
+var debug_1 = debug;
+
+var re_1 = createCommonjsModule(function (module, exports) {
+const { MAX_SAFE_COMPONENT_LENGTH } = constants;
+
+exports = module.exports = {};
+
+// The actual regexps go on exports.re
+const re = exports.re = [];
+const src = exports.src = [];
+const t = exports.t = {};
+let R = 0;
+
+const createToken = (name, value, isGlobal) => {
+  const index = R++;
+  debug_1(index, value);
+  t[name] = index;
+  src[index] = value;
+  re[index] = new RegExp(value, isGlobal ? 'g' : undefined);
+};
+
+// The following Regular Expressions can be used for tokenizing,
+// validating, and parsing SemVer version strings.
+
+// ## Numeric Identifier
+// A single `0`, or a non-zero digit followed by zero or more digits.
+
+createToken('NUMERICIDENTIFIER', '0|[1-9]\\d*');
+createToken('NUMERICIDENTIFIERLOOSE', '[0-9]+');
+
+// ## Non-numeric Identifier
+// Zero or more digits, followed by a letter or hyphen, and then zero or
+// more letters, digits, or hyphens.
+
+createToken('NONNUMERICIDENTIFIER', '\\d*[a-zA-Z-][a-zA-Z0-9-]*');
+
+// ## Main Version
+// Three dot-separated numeric identifiers.
+
+createToken('MAINVERSION', `(${src[t.NUMERICIDENTIFIER]})\\.` +
+                   `(${src[t.NUMERICIDENTIFIER]})\\.` +
+                   `(${src[t.NUMERICIDENTIFIER]})`);
+
+createToken('MAINVERSIONLOOSE', `(${src[t.NUMERICIDENTIFIERLOOSE]})\\.` +
+                        `(${src[t.NUMERICIDENTIFIERLOOSE]})\\.` +
+                        `(${src[t.NUMERICIDENTIFIERLOOSE]})`);
+
+// ## Pre-release Version Identifier
+// A numeric identifier, or a non-numeric identifier.
+
+createToken('PRERELEASEIDENTIFIER', `(?:${src[t.NUMERICIDENTIFIER]
+}|${src[t.NONNUMERICIDENTIFIER]})`);
+
+createToken('PRERELEASEIDENTIFIERLOOSE', `(?:${src[t.NUMERICIDENTIFIERLOOSE]
+}|${src[t.NONNUMERICIDENTIFIER]})`);
+
+// ## Pre-release Version
+// Hyphen, followed by one or more dot-separated pre-release version
+// identifiers.
+
+createToken('PRERELEASE', `(?:-(${src[t.PRERELEASEIDENTIFIER]
+}(?:\\.${src[t.PRERELEASEIDENTIFIER]})*))`);
+
+createToken('PRERELEASELOOSE', `(?:-?(${src[t.PRERELEASEIDENTIFIERLOOSE]
+}(?:\\.${src[t.PRERELEASEIDENTIFIERLOOSE]})*))`);
+
+// ## Build Metadata Identifier
+// Any combination of digits, letters, or hyphens.
+
+createToken('BUILDIDENTIFIER', '[0-9A-Za-z-]+');
+
+// ## Build Metadata
+// Plus sign, followed by one or more period-separated build metadata
+// identifiers.
+
+createToken('BUILD', `(?:\\+(${src[t.BUILDIDENTIFIER]
+}(?:\\.${src[t.BUILDIDENTIFIER]})*))`);
+
+// ## Full Version String
+// A main version, followed optionally by a pre-release version and
+// build metadata.
+
+// Note that the only major, minor, patch, and pre-release sections of
+// the version string are capturing groups.  The build metadata is not a
+// capturing group, because it should not ever be used in version
+// comparison.
+
+createToken('FULLPLAIN', `v?${src[t.MAINVERSION]
+}${src[t.PRERELEASE]}?${
+  src[t.BUILD]}?`);
+
+createToken('FULL', `^${src[t.FULLPLAIN]}$`);
+
+// like full, but allows v1.2.3 and =1.2.3, which people do sometimes.
+// also, 1.0.0alpha1 (prerelease without the hyphen) which is pretty
+// common in the npm registry.
+createToken('LOOSEPLAIN', `[v=\\s]*${src[t.MAINVERSIONLOOSE]
+}${src[t.PRERELEASELOOSE]}?${
+  src[t.BUILD]}?`);
+
+createToken('LOOSE', `^${src[t.LOOSEPLAIN]}$`);
+
+createToken('GTLT', '((?:<|>)?=?)');
+
+// Something like "2.*" or "1.2.x".
+// Note that "x.x" is a valid xRange identifer, meaning "any version"
+// Only the first item is strictly required.
+createToken('XRANGEIDENTIFIERLOOSE', `${src[t.NUMERICIDENTIFIERLOOSE]}|x|X|\\*`);
+createToken('XRANGEIDENTIFIER', `${src[t.NUMERICIDENTIFIER]}|x|X|\\*`);
+
+createToken('XRANGEPLAIN', `[v=\\s]*(${src[t.XRANGEIDENTIFIER]})` +
+                   `(?:\\.(${src[t.XRANGEIDENTIFIER]})` +
+                   `(?:\\.(${src[t.XRANGEIDENTIFIER]})` +
+                   `(?:${src[t.PRERELEASE]})?${
+                     src[t.BUILD]}?` +
+                   `)?)?`);
+
+createToken('XRANGEPLAINLOOSE', `[v=\\s]*(${src[t.XRANGEIDENTIFIERLOOSE]})` +
+                        `(?:\\.(${src[t.XRANGEIDENTIFIERLOOSE]})` +
+                        `(?:\\.(${src[t.XRANGEIDENTIFIERLOOSE]})` +
+                        `(?:${src[t.PRERELEASELOOSE]})?${
+                          src[t.BUILD]}?` +
+                        `)?)?`);
+
+createToken('XRANGE', `^${src[t.GTLT]}\\s*${src[t.XRANGEPLAIN]}$`);
+createToken('XRANGELOOSE', `^${src[t.GTLT]}\\s*${src[t.XRANGEPLAINLOOSE]}$`);
+
+// Coercion.
+// Extract anything that could conceivably be a part of a valid semver
+createToken('COERCE', `${'(^|[^\\d])' +
+              '(\\d{1,'}${MAX_SAFE_COMPONENT_LENGTH}})` +
+              `(?:\\.(\\d{1,${MAX_SAFE_COMPONENT_LENGTH}}))?` +
+              `(?:\\.(\\d{1,${MAX_SAFE_COMPONENT_LENGTH}}))?` +
+              `(?:$|[^\\d])`);
+createToken('COERCERTL', src[t.COERCE], true);
+
+// Tilde ranges.
+// Meaning is "reasonably at or greater than"
+createToken('LONETILDE', '(?:~>?)');
+
+createToken('TILDETRIM', `(\\s*)${src[t.LONETILDE]}\\s+`, true);
+exports.tildeTrimReplace = '$1~';
+
+createToken('TILDE', `^${src[t.LONETILDE]}${src[t.XRANGEPLAIN]}$`);
+createToken('TILDELOOSE', `^${src[t.LONETILDE]}${src[t.XRANGEPLAINLOOSE]}$`);
+
+// Caret ranges.
+// Meaning is "at least and backwards compatible with"
+createToken('LONECARET', '(?:\\^)');
+
+createToken('CARETTRIM', `(\\s*)${src[t.LONECARET]}\\s+`, true);
+exports.caretTrimReplace = '$1^';
+
+createToken('CARET', `^${src[t.LONECARET]}${src[t.XRANGEPLAIN]}$`);
+createToken('CARETLOOSE', `^${src[t.LONECARET]}${src[t.XRANGEPLAINLOOSE]}$`);
+
+// A simple gt/lt/eq thing, or just "" to indicate "any version"
+createToken('COMPARATORLOOSE', `^${src[t.GTLT]}\\s*(${src[t.LOOSEPLAIN]})$|^$`);
+createToken('COMPARATOR', `^${src[t.GTLT]}\\s*(${src[t.FULLPLAIN]})$|^$`);
+
+// An expression to strip any whitespace between the gtlt and the thing
+// it modifies, so that `> 1.2.3` ==> `>1.2.3`
+createToken('COMPARATORTRIM', `(\\s*)${src[t.GTLT]
+}\\s*(${src[t.LOOSEPLAIN]}|${src[t.XRANGEPLAIN]})`, true);
+exports.comparatorTrimReplace = '$1$2$3';
+
+// Something like `1.2.3 - 1.2.4`
+// Note that these all use the loose form, because they'll be
+// checked against either the strict or loose comparator form
+// later.
+createToken('HYPHENRANGE', `^\\s*(${src[t.XRANGEPLAIN]})` +
+                   `\\s+-\\s+` +
+                   `(${src[t.XRANGEPLAIN]})` +
+                   `\\s*$`);
+
+createToken('HYPHENRANGELOOSE', `^\\s*(${src[t.XRANGEPLAINLOOSE]})` +
+                        `\\s+-\\s+` +
+                        `(${src[t.XRANGEPLAINLOOSE]})` +
+                        `\\s*$`);
+
+// Star ranges basically just allow anything at all.
+createToken('STAR', '(<|>)?=?\\s*\\*');
+// >=0.0.0 is like a star
+createToken('GTE0', '^\\s*>=\\s*0\.0\.0\\s*$');
+createToken('GTE0PRE', '^\\s*>=\\s*0\.0\.0-0\\s*$');
+});
+
+// parse out just the options we care about so we always get a consistent
+// obj with keys in a consistent order.
+const opts = ['includePrerelease', 'loose', 'rtl'];
+const parseOptions = options =>
+  !options ? {}
+  : typeof options !== 'object' ? { loose: true }
+  : opts.filter(k => options[k]).reduce((options, k) => {
+    options[k] = true;
+    return options
+  }, {});
+var parseOptions_1 = parseOptions;
+
+const numeric = /^[0-9]+$/;
+const compareIdentifiers$1 = (a, b) => {
+  const anum = numeric.test(a);
+  const bnum = numeric.test(b);
+
+  if (anum && bnum) {
+    a = +a;
+    b = +b;
+  }
+
+  return a === b ? 0
+    : (anum && !bnum) ? -1
+    : (bnum && !anum) ? 1
+    : a < b ? -1
+    : 1
+};
+
+const rcompareIdentifiers = (a, b) => compareIdentifiers$1(b, a);
+
+var identifiers = {
+  compareIdentifiers: compareIdentifiers$1,
+  rcompareIdentifiers
+};
+
+const { MAX_LENGTH: MAX_LENGTH$1, MAX_SAFE_INTEGER } = constants;
+const { re: re$1, t: t$1 } = re_1;
+
+
+const { compareIdentifiers } = identifiers;
+class SemVer {
+  constructor (version, options) {
+    options = parseOptions_1(options);
+
+    if (version instanceof SemVer) {
+      if (version.loose === !!options.loose &&
+          version.includePrerelease === !!options.includePrerelease) {
+        return version
+      } else {
+        version = version.version;
+      }
+    } else if (typeof version !== 'string') {
+      throw new TypeError(`Invalid Version: ${version}`)
+    }
+
+    if (version.length > MAX_LENGTH$1) {
+      throw new TypeError(
+        `version is longer than ${MAX_LENGTH$1} characters`
+      )
+    }
+
+    debug_1('SemVer', version, options);
+    this.options = options;
+    this.loose = !!options.loose;
+    // this isn't actually relevant for versions, but keep it so that we
+    // don't run into trouble passing this.options around.
+    this.includePrerelease = !!options.includePrerelease;
+
+    const m = version.trim().match(options.loose ? re$1[t$1.LOOSE] : re$1[t$1.FULL]);
+
+    if (!m) {
+      throw new TypeError(`Invalid Version: ${version}`)
+    }
+
+    this.raw = version;
+
+    // these are actually numbers
+    this.major = +m[1];
+    this.minor = +m[2];
+    this.patch = +m[3];
+
+    if (this.major > MAX_SAFE_INTEGER || this.major < 0) {
+      throw new TypeError('Invalid major version')
+    }
+
+    if (this.minor > MAX_SAFE_INTEGER || this.minor < 0) {
+      throw new TypeError('Invalid minor version')
+    }
+
+    if (this.patch > MAX_SAFE_INTEGER || this.patch < 0) {
+      throw new TypeError('Invalid patch version')
+    }
+
+    // numberify any prerelease numeric ids
+    if (!m[4]) {
+      this.prerelease = [];
+    } else {
+      this.prerelease = m[4].split('.').map((id) => {
+        if (/^[0-9]+$/.test(id)) {
+          const num = +id;
+          if (num >= 0 && num < MAX_SAFE_INTEGER) {
+            return num
+          }
+        }
+        return id
+      });
+    }
+
+    this.build = m[5] ? m[5].split('.') : [];
+    this.format();
+  }
+
+  format () {
+    this.version = `${this.major}.${this.minor}.${this.patch}`;
+    if (this.prerelease.length) {
+      this.version += `-${this.prerelease.join('.')}`;
+    }
+    return this.version
+  }
+
+  toString () {
+    return this.version
+  }
+
+  compare (other) {
+    debug_1('SemVer.compare', this.version, this.options, other);
+    if (!(other instanceof SemVer)) {
+      if (typeof other === 'string' && other === this.version) {
+        return 0
+      }
+      other = new SemVer(other, this.options);
+    }
+
+    if (other.version === this.version) {
+      return 0
+    }
+
+    return this.compareMain(other) || this.comparePre(other)
+  }
+
+  compareMain (other) {
+    if (!(other instanceof SemVer)) {
+      other = new SemVer(other, this.options);
+    }
+
+    return (
+      compareIdentifiers(this.major, other.major) ||
+      compareIdentifiers(this.minor, other.minor) ||
+      compareIdentifiers(this.patch, other.patch)
+    )
+  }
+
+  comparePre (other) {
+    if (!(other instanceof SemVer)) {
+      other = new SemVer(other, this.options);
+    }
+
+    // NOT having a prerelease is > having one
+    if (this.prerelease.length && !other.prerelease.length) {
+      return -1
+    } else if (!this.prerelease.length && other.prerelease.length) {
+      return 1
+    } else if (!this.prerelease.length && !other.prerelease.length) {
+      return 0
+    }
+
+    let i = 0;
+    do {
+      const a = this.prerelease[i];
+      const b = other.prerelease[i];
+      debug_1('prerelease compare', i, a, b);
+      if (a === undefined && b === undefined) {
+        return 0
+      } else if (b === undefined) {
+        return 1
+      } else if (a === undefined) {
+        return -1
+      } else if (a === b) {
+        continue
+      } else {
+        return compareIdentifiers(a, b)
+      }
+    } while (++i)
+  }
+
+  compareBuild (other) {
+    if (!(other instanceof SemVer)) {
+      other = new SemVer(other, this.options);
+    }
+
+    let i = 0;
+    do {
+      const a = this.build[i];
+      const b = other.build[i];
+      debug_1('prerelease compare', i, a, b);
+      if (a === undefined && b === undefined) {
+        return 0
+      } else if (b === undefined) {
+        return 1
+      } else if (a === undefined) {
+        return -1
+      } else if (a === b) {
+        continue
+      } else {
+        return compareIdentifiers(a, b)
+      }
+    } while (++i)
+  }
+
+  // preminor will bump the version up to the next minor release, and immediately
+  // down to pre-release. premajor and prepatch work the same way.
+  inc (release, identifier) {
+    switch (release) {
+      case 'premajor':
+        this.prerelease.length = 0;
+        this.patch = 0;
+        this.minor = 0;
+        this.major++;
+        this.inc('pre', identifier);
+        break
+      case 'preminor':
+        this.prerelease.length = 0;
+        this.patch = 0;
+        this.minor++;
+        this.inc('pre', identifier);
+        break
+      case 'prepatch':
+        // If this is already a prerelease, it will bump to the next version
+        // drop any prereleases that might already exist, since they are not
+        // relevant at this point.
+        this.prerelease.length = 0;
+        this.inc('patch', identifier);
+        this.inc('pre', identifier);
+        break
+      // If the input is a non-prerelease version, this acts the same as
+      // prepatch.
+      case 'prerelease':
+        if (this.prerelease.length === 0) {
+          this.inc('patch', identifier);
+        }
+        this.inc('pre', identifier);
+        break
+
+      case 'major':
+        // If this is a pre-major version, bump up to the same major version.
+        // Otherwise increment major.
+        // 1.0.0-5 bumps to 1.0.0
+        // 1.1.0 bumps to 2.0.0
+        if (
+          this.minor !== 0 ||
+          this.patch !== 0 ||
+          this.prerelease.length === 0
+        ) {
+          this.major++;
+        }
+        this.minor = 0;
+        this.patch = 0;
+        this.prerelease = [];
+        break
+      case 'minor':
+        // If this is a pre-minor version, bump up to the same minor version.
+        // Otherwise increment minor.
+        // 1.2.0-5 bumps to 1.2.0
+        // 1.2.1 bumps to 1.3.0
+        if (this.patch !== 0 || this.prerelease.length === 0) {
+          this.minor++;
+        }
+        this.patch = 0;
+        this.prerelease = [];
+        break
+      case 'patch':
+        // If this is not a pre-release version, it will increment the patch.
+        // If it is a pre-release it will bump up to the same patch version.
+        // 1.2.0-5 patches to 1.2.0
+        // 1.2.0 patches to 1.2.1
+        if (this.prerelease.length === 0) {
+          this.patch++;
+        }
+        this.prerelease = [];
+        break
+      // This probably shouldn't be used publicly.
+      // 1.0.0 'pre' would become 1.0.0-0 which is the wrong direction.
+      case 'pre':
+        if (this.prerelease.length === 0) {
+          this.prerelease = [0];
+        } else {
+          let i = this.prerelease.length;
+          while (--i >= 0) {
+            if (typeof this.prerelease[i] === 'number') {
+              this.prerelease[i]++;
+              i = -2;
+            }
+          }
+          if (i === -1) {
+            // didn't increment anything
+            this.prerelease.push(0);
+          }
+        }
+        if (identifier) {
+          // 1.2.0-beta.1 bumps to 1.2.0-beta.2,
+          // 1.2.0-beta.fooblz or 1.2.0-beta bumps to 1.2.0-beta.0
+          if (this.prerelease[0] === identifier) {
+            if (isNaN(this.prerelease[1])) {
+              this.prerelease = [identifier, 0];
+            }
+          } else {
+            this.prerelease = [identifier, 0];
+          }
+        }
+        break
+
+      default:
+        throw new Error(`invalid increment argument: ${release}`)
+    }
+    this.format();
+    this.raw = this.version;
+    return this
+  }
+}
+
+var semver = SemVer;
+
+const {MAX_LENGTH} = constants;
+const { re, t } = re_1;
+
+
+
+const parse = (version, options) => {
+  options = parseOptions_1(options);
+
+  if (version instanceof semver) {
+    return version
+  }
+
+  if (typeof version !== 'string') {
+    return null
+  }
+
+  if (version.length > MAX_LENGTH) {
+    return null
+  }
+
+  const r = options.loose ? re[t.LOOSE] : re[t.FULL];
+  if (!r.test(version)) {
+    return null
+  }
+
+  try {
+    return new semver(version, options)
+  } catch (er) {
+    return null
+  }
+};
+
+var parse_1 = parse;
+
+function parseTag(options) {
+  const {
+    tag,
+    tagPrefix
+  } = options;
+  const semver = parse_1(tag.tag, {
+    includePrerelease: true
+  });
+
+  if (!tag.tag.startsWith(tagPrefix) || semver === null) {
+    return null;
+  }
+
+  return semver;
+}
+
+function findAncestorTag(options) {
+  const {
+    tagPrefix,
+    tags,
+    commit,
+    repository
+  } = options;
+  const tagQueue = [...tags];
+  const tag = tagQueue.shift();
+
+  if (tag == null) {
+    return Promise.resolve(null);
+  }
+
+  const semver = parseTag({
+    tagPrefix,
+    tag
+  });
+
+  if (semver === null) {
+    return findAncestorTag({ ...options,
+      tags: tagQueue
+    });
+  }
+
+  return compareTag({
+    tag,
+    commit,
+    repository
+  }).then(result => {
+    if (result == null) {
+      return findAncestorTag({ ...options,
+        tags: tagQueue
+      });
+    }
+
+    return { ...result,
+      semver
+    };
+  });
+}
+
+const inc = (version, release, options, identifier) => {
+  if (typeof (options) === 'string') {
+    identifier = options;
+    options = undefined;
+  }
+
+  try {
+    return new semver(version, options).inc(release, identifier).version
+  } catch (er) {
+    return null
+  }
+};
+var inc_1 = inc;
+
+function buildVersionString(options) {
+  const {
+    ancestor,
+    commit,
+    prereleaseId,
+    snapshotId
+  } = options;
+  const shortSha = commit.commit.slice(0, 7);
+
+  if (ancestor === null) {
+    return `0.0.0-${snapshotId}+${shortSha}`;
+  }
+
+  if (ancestor.distance === 0) {
+    return ancestor.semver.version;
+  }
+
+  const {
+    semver,
+    distance
+  } = ancestor;
+  const prevIsPrerelease = semver.prerelease.length > 0;
+  const bump = prevIsPrerelease ? 'prerelease' : options.bump;
+  const nextIsPrerelease = bump.startsWith('pre');
+  const nextVersion = inc_1(semver, bump, prereleaseId);
+  const dotOrDash = nextIsPrerelease ? '.' : '-';
+  const snapshotPostfix = `${snapshotId}.${distance}+${shortSha}`;
+  return `${nextVersion}${dotOrDash}${snapshotPostfix}`;
+}
+
+function getGitVersion() {
+  const tagPrefix = getInput('tag-prefix');
+  const prereleaseId = getInput('prerelease-id');
+  const snapshotId = getInput('snapshot-id');
+  const bump = getInput('bump');
+  const repository = getRepository();
+  const commit = getCommit();
+  return getTagList({
+    tagPrefix,
+    repository
+  }).then(tags => findAncestorTag({
+    tags,
+    commit,
+    tagPrefix,
+    repository
+  })).then(ancestor => {
+    return buildVersionString({
+      ancestor,
+      commit,
+      bump,
+      prereleaseId,
+      snapshotId
+    });
+  });
+}
+
+// action entry point
+getGitVersion().then(version => setOutput('version', version)).catch(error => setFailed(error));
+//# sourceMappingURL=main.js.map

--- a/git-version/dist/main.js
+++ b/git-version/dist/main.js
@@ -6096,7 +6096,7 @@ const TAG_LIST_QUERY = `query tagList($owner: String!, $repo: String!, $match: S
   repository(owner: $owner, name: $repo) {
     refs(
       refPrefix: "refs/tags/",
-      orderBy: { field: TAG_COMMIT_DATE, direction:DESC },
+      orderBy: { field: TAG_COMMIT_DATE, direction: DESC },
       first: 20,
       query: $match
     ) {
@@ -6746,7 +6746,6 @@ function findAncestorTag(options) {
   const tag = tagQueue.shift();
 
   if (tag == null) {
-    log.warning('Unable to find a valid version tag');
     return Promise.resolve(null);
   }
 
@@ -6756,7 +6755,7 @@ function findAncestorTag(options) {
   });
 
   if (semver === null) {
-    log.warning(`Tag ${tag.tag} did not start with ${tagPrefix} or could not be parsed as SemVer. Continuing search.`);
+    log.warning(`Tag ${tag.tag} did not match ${tagPrefix} or could not be parsed. Continuing search.`);
     return findAncestorTag({ ...options,
       tags: tagQueue
     });
@@ -6830,14 +6829,6 @@ function getGitVersion() {
   const bump = getInput('bump');
   const repository = getRepository();
   const commit = getCommit();
-  log.debug(`
-Calculating version from git:
-- Tag prefix: ${tagPrefix}
-- Bump: ${bump}
-- Repository: ${repository.owner}/${repository.repo}
-- Snapshot identifier: ${snapshotId}
-- Prerelease identifier: ${prereleaseId}
-`.trim());
   return getTagList({
     tagPrefix,
     repository
@@ -6850,19 +6841,20 @@ Calculating version from git:
       repository
     });
   }).then(ancestor => {
-    log.debug(`Found tag ancestor ${JSON.stringify(ancestor)}`);
-    const version = buildVersionString({
+    log.debug(`Found ancestor tag ${JSON.stringify(ancestor)}`);
+    return buildVersionString({
       ancestor,
       commit,
       bump,
       prereleaseId,
       snapshotId
     });
-    log.info(`Generated version: ${version}`);
-    return version;
   });
 }
 
 // action entry point
-getGitVersion().then(version => setOutput('version', version)).catch(error => setFailed(error));
+getGitVersion().then(version => {
+  log.info(`Generated version: ${version}`);
+  setOutput('version', version);
+}).catch(error => setFailed(error));
 //# sourceMappingURL=main.js.map

--- a/git-version/dist/main.js
+++ b/git-version/dist/main.js
@@ -6117,10 +6117,8 @@ function getTagList(options) {
     match: tagPrefix
   };
   return getOctokit().graphql(TAG_LIST_QUERY, { ...variables
-  }).then(({
-    tagList
-  }) => {
-    return tagList.repository.refs.nodes.map(node => ({
+  }).then(result => {
+    return result.repository.refs.nodes.map(node => ({
       tag: node.name
     }));
   });

--- a/git-version/src/__tests__/getGitVersion.test.ts
+++ b/git-version/src/__tests__/getGitVersion.test.ts
@@ -1,0 +1,86 @@
+import { SemVer } from 'semver'
+import { when } from 'jest-when'
+
+import {
+  Commit,
+  Repository,
+  Tag,
+  getInput,
+  getRepository,
+  getCommit,
+  getTagList,
+} from '../github'
+
+import {
+  ParsedAncestorTag,
+  findAncestorTag,
+  buildVersionString,
+} from '../versioning'
+
+import { getGitVersion } from '../getGitVersion'
+
+jest.mock('../github')
+jest.mock('../versioning')
+
+const REPOSITORY: Repository = {
+  owner: 'owner-name',
+  repo: 'repo-name',
+}
+
+const COMMIT: Commit = {
+  commit: 'abc123',
+}
+
+const TAG_LIST: Tag[] = [
+  { tag: 'v1.2.3' },
+  { tag: 'v4.5.6' },
+  { tag: 'v7.8.9' },
+]
+
+const ANCESTOR_TAG: ParsedAncestorTag = {
+  tag: 'v4.5.6',
+  distance: 42,
+  semver: new SemVer('v4.5.6'),
+}
+
+describe('get git version', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should get the list of tags, find the closest ancestor, and increment it', async () => {
+    when(getInput).calledWith('tag-prefix').mockReturnValue('v')
+    when(getInput).calledWith('bump').mockReturnValue('preminor')
+    when(getInput).calledWith('prerelease-id').mockReturnValue('alpha')
+    when(getInput).calledWith('snapshot-id').mockReturnValue('dev')
+    when(getCommit).calledWith().mockReturnValue(COMMIT)
+    when(getRepository).calledWith().mockReturnValue(REPOSITORY)
+
+    when(getTagList)
+      .calledWith({ tagPrefix: 'v', repository: REPOSITORY })
+      .mockResolvedValue(TAG_LIST)
+
+    when(findAncestorTag)
+      .calledWith({
+        tagPrefix: 'v',
+        tags: TAG_LIST,
+        commit: COMMIT,
+        repository: REPOSITORY,
+      })
+      .mockResolvedValue(ANCESTOR_TAG)
+
+    when(buildVersionString)
+      .calledWith({
+        ancestor: ANCESTOR_TAG,
+        commit: COMMIT,
+        bump: 'preminor',
+        prereleaseId: 'alpha',
+        snapshotId: 'dev',
+      })
+      .mockReturnValue('v0.0.0')
+
+    const version = await getGitVersion()
+
+    expect(version).toBe('v0.0.0')
+  })
+})

--- a/git-version/src/getGitVersion.ts
+++ b/git-version/src/getGitVersion.ts
@@ -9,7 +9,7 @@ export function getGitVersion(): Promise<string> {
   const repository = getRepository()
   const commit = getCommit()
 
-  log.info(
+  log.debug(
     `
 Calculating version from git:
 - Tag prefix: ${tagPrefix}
@@ -21,8 +21,14 @@ Calculating version from git:
   )
 
   return getTagList({ tagPrefix, repository })
-    .then((tags) => findAncestorTag({ tags, commit, tagPrefix, repository }))
+    .then((tags) => {
+      log.debug(`Found tags ${JSON.stringify(tags, null, 2)}`)
+
+      return findAncestorTag({ tags, commit, tagPrefix, repository })
+    })
     .then((ancestor) => {
+      log.debug(`Found tag ancestor ${JSON.stringify(ancestor)}`)
+
       const version = buildVersionString({
         ancestor,
         commit,

--- a/git-version/src/getGitVersion.ts
+++ b/git-version/src/getGitVersion.ts
@@ -9,17 +9,6 @@ export function getGitVersion(): Promise<string> {
   const repository = getRepository()
   const commit = getCommit()
 
-  log.debug(
-    `
-Calculating version from git:
-- Tag prefix: ${tagPrefix}
-- Bump: ${bump}
-- Repository: ${repository.owner}/${repository.repo}
-- Snapshot identifier: ${snapshotId}
-- Prerelease identifier: ${prereleaseId}
-`.trim()
-  )
-
   return getTagList({ tagPrefix, repository })
     .then((tags) => {
       log.debug(`Found tags ${JSON.stringify(tags, null, 2)}`)
@@ -27,17 +16,14 @@ Calculating version from git:
       return findAncestorTag({ tags, commit, tagPrefix, repository })
     })
     .then((ancestor) => {
-      log.debug(`Found tag ancestor ${JSON.stringify(ancestor)}`)
+      log.debug(`Found ancestor tag ${JSON.stringify(ancestor)}`)
 
-      const version = buildVersionString({
+      return buildVersionString({
         ancestor,
         commit,
         bump,
         prereleaseId,
         snapshotId,
       })
-
-      log.info(`Generated version: ${version}`)
-      return version
     })
 }

--- a/git-version/src/getGitVersion.ts
+++ b/git-version/src/getGitVersion.ts
@@ -1,23 +1,37 @@
-import { getInput, getRepository, getCommit, getTagList } from './github'
+import { log, getInput, getRepository, getCommit, getTagList } from './github'
 import { Bump, findAncestorTag, buildVersionString } from './versioning'
 
 export function getGitVersion(): Promise<string> {
   const tagPrefix = getInput('tag-prefix')
-  const prereleaseId = getInput('prerelease-id')
   const snapshotId = getInput('snapshot-id')
+  const prereleaseId = getInput('prerelease-id')
   const bump = getInput('bump') as Bump
   const repository = getRepository()
   const commit = getCommit()
 
+  log.info(
+    `
+Calculating version from git:
+- Tag prefix: ${tagPrefix}
+- Bump: ${bump}
+- Repository: ${repository.owner}/${repository.repo}
+- Snapshot identifier: ${snapshotId}
+- Prerelease identifier: ${prereleaseId}
+`.trim()
+  )
+
   return getTagList({ tagPrefix, repository })
     .then((tags) => findAncestorTag({ tags, commit, tagPrefix, repository }))
     .then((ancestor) => {
-      return buildVersionString({
+      const version = buildVersionString({
         ancestor,
         commit,
         bump,
         prereleaseId,
         snapshotId,
       })
+
+      log.info(`Generated version: ${version}`)
+      return version
     })
 }

--- a/git-version/src/getGitVersion.ts
+++ b/git-version/src/getGitVersion.ts
@@ -1,0 +1,23 @@
+import { getInput, getRepository, getCommit, getTagList } from './github'
+import { Bump, findAncestorTag, buildVersionString } from './versioning'
+
+export function getGitVersion(): Promise<string> {
+  const tagPrefix = getInput('tag-prefix')
+  const prereleaseId = getInput('prerelease-id')
+  const snapshotId = getInput('snapshot-id')
+  const bump = getInput('bump') as Bump
+  const repository = getRepository()
+  const commit = getCommit()
+
+  return getTagList({ tagPrefix, repository })
+    .then((tags) => findAncestorTag({ tags, commit, tagPrefix, repository }))
+    .then((ancestor) => {
+      return buildVersionString({
+        ancestor,
+        commit,
+        bump,
+        prereleaseId,
+        snapshotId,
+      })
+    })
+}

--- a/git-version/src/github/compareTag.ts
+++ b/git-version/src/github/compareTag.ts
@@ -1,5 +1,5 @@
 import { Commit, Repository, Tag, AncestorTag } from './types'
-import { getOctokit } from './core'
+import { log, getOctokit } from './core'
 
 export interface CompareTagOptions {
   tag: Tag
@@ -14,9 +14,13 @@ export function compareTag(
   const params = { ...repository, base: tag.tag, head: commit.commit }
   const octokit = getOctokit()
 
+  log.debug(`Comparing base ${params.base} to head ${params.head}`)
+
   return octokit.repos.compareCommits(params).then((response) => {
     const { status, ahead_by: distance } = response.data
     const isAnscestor = status === 'ahead' || status === 'identical'
+
+    log.debug(`Head is ${status}, ahead by ${distance}`)
 
     return isAnscestor ? { ...tag, distance } : null
   })

--- a/git-version/src/github/compareTag.ts
+++ b/git-version/src/github/compareTag.ts
@@ -1,0 +1,23 @@
+import { Commit, Repository, Tag, AncestorTag } from './types'
+import { getOctokit } from './core'
+
+export interface CompareTagOptions {
+  tag: Tag
+  commit: Commit
+  repository: Repository
+}
+
+export function compareTag(
+  options: CompareTagOptions
+): Promise<AncestorTag | null> {
+  const { tag, commit, repository } = options
+  const params = { ...repository, base: tag.tag, head: commit.commit }
+  const octokit = getOctokit()
+
+  return octokit.repos.compareCommits(params).then((response) => {
+    const { status, ahead_by: distance } = response.data
+    const isAnscestor = status === 'ahead' || status === 'identical'
+
+    return isAnscestor ? { ...tag, distance } : null
+  })
+}

--- a/git-version/src/github/core.ts
+++ b/git-version/src/github/core.ts
@@ -7,6 +7,13 @@ export type Octokit = ReturnType<typeof github.getOctokit>
 
 let _octokit: Octokit | null = null
 
+export const log = {
+  error: (message: string | Error) => core.error(message),
+  warning: (message: string | Error) => core.warning(message),
+  info: (message: string) => core.info(message),
+  debug: (message: string) => core.debug(message),
+}
+
 export function getCommit(): Commit {
   return { commit: github.context.sha }
 }

--- a/git-version/src/github/core.ts
+++ b/git-version/src/github/core.ts
@@ -1,0 +1,37 @@
+import github from '@actions/github'
+import core from '@actions/core'
+
+import { Commit, Repository, InputName, OutputName } from './types'
+
+export type Octokit = ReturnType<typeof github.getOctokit>
+
+let _octokit: Octokit | null = null
+
+export function getCommit(): Commit {
+  return { commit: github.context.sha }
+}
+
+export function getRepository(): Repository {
+  return github.context.repo
+}
+
+export function getInput(name: InputName, required = true): string {
+  return core.getInput(name, { required })
+}
+
+export function setOutput(name: OutputName, value: string): void {
+  core.setOutput(name, value)
+}
+
+export function setFailed(message: string | Error): void {
+  core.setFailed(message)
+}
+
+export function getOctokit(): Octokit {
+  if (_octokit === null) {
+    const githubToken = getInput('github-token')
+    _octokit = github.getOctokit(githubToken)
+  }
+
+  return _octokit
+}

--- a/git-version/src/github/getTagList.ts
+++ b/git-version/src/github/getTagList.ts
@@ -9,7 +9,7 @@ export interface TagListOptions {
 interface TagListQueryVariables {
   owner: string
   repo: string
-  query: string
+  match: string
 }
 
 interface TagListQuery {
@@ -24,13 +24,13 @@ interface TagListQuery {
   }
 }
 
-const TAG_LIST_QUERY = `query tagList($owner: String!, $repo: String!, $query: String!) {
+const TAG_LIST_QUERY = `query tagList($owner: String!, $repo: String!, $match: String!) {
   repository(owner: $owner, name: $repo) {
     refs(
       refPrefix: "refs/tags/",
       orderBy: { field: TAG_COMMIT_DATE, direction:DESC },
       first: 20,
-      query: $query
+      query: $match
     ) {
       nodes {
         name
@@ -44,11 +44,11 @@ export function getTagList(options: TagListOptions): Promise<Tag[]> {
   const variables: TagListQueryVariables = {
     owner: repository.owner,
     repo: repository.repo,
-    query: tagPrefix,
+    match: tagPrefix,
   }
 
   return getOctokit()
-    .graphql<TagListQuery>(TAG_LIST_QUERY, { variables })
+    .graphql<TagListQuery>(TAG_LIST_QUERY, { ...variables })
     .then(({ tagList }) => {
       return tagList.repository.refs.nodes.map((node) => ({ tag: node.name }))
     })

--- a/git-version/src/github/getTagList.ts
+++ b/git-version/src/github/getTagList.ts
@@ -1,0 +1,55 @@
+import { Repository, Tag } from './types'
+import { getOctokit } from './core'
+
+export interface TagListOptions {
+  tagPrefix: string
+  repository: Repository
+}
+
+interface TagListQueryVariables {
+  owner: string
+  repo: string
+  query: string
+}
+
+interface TagListQuery {
+  tagList: {
+    repository: {
+      refs: {
+        nodes: Array<{
+          name: string
+        }>
+      }
+    }
+  }
+}
+
+const TAG_LIST_QUERY = `query tagList($owner: String!, $repo: String!, $query: String!) {
+  repository(owner: $owner, name: $repo) {
+    refs(
+      refPrefix: "refs/tags/",
+      orderBy: { field: TAG_COMMIT_DATE, direction:DESC },
+      first: 20,
+      query: $query
+    ) {
+      nodes {
+        name
+      }
+    }
+  }
+}`
+
+export function getTagList(options: TagListOptions): Promise<Tag[]> {
+  const { repository, tagPrefix } = options
+  const variables: TagListQueryVariables = {
+    owner: repository.owner,
+    repo: repository.repo,
+    query: tagPrefix,
+  }
+
+  return getOctokit()
+    .graphql<TagListQuery>(TAG_LIST_QUERY, { variables })
+    .then(({ tagList }) => {
+      return tagList.repository.refs.nodes.map((node) => ({ tag: node.name }))
+    })
+}

--- a/git-version/src/github/getTagList.ts
+++ b/git-version/src/github/getTagList.ts
@@ -12,14 +12,12 @@ interface TagListQueryVariables {
   match: string
 }
 
-interface TagListQuery {
-  tagList: {
-    repository: {
-      refs: {
-        nodes: Array<{
-          name: string
-        }>
-      }
+interface TagListQueryResult {
+  repository: {
+    refs: {
+      nodes: Array<{
+        name: string
+      }>
     }
   }
 }
@@ -48,8 +46,8 @@ export function getTagList(options: TagListOptions): Promise<Tag[]> {
   }
 
   return getOctokit()
-    .graphql<TagListQuery>(TAG_LIST_QUERY, { ...variables })
-    .then(({ tagList }) => {
-      return tagList.repository.refs.nodes.map((node) => ({ tag: node.name }))
+    .graphql<TagListQueryResult>(TAG_LIST_QUERY, { ...variables })
+    .then((result) => {
+      return result.repository.refs.nodes.map((node) => ({ tag: node.name }))
     })
 }

--- a/git-version/src/github/getTagList.ts
+++ b/git-version/src/github/getTagList.ts
@@ -26,7 +26,7 @@ const TAG_LIST_QUERY = `query tagList($owner: String!, $repo: String!, $match: S
   repository(owner: $owner, name: $repo) {
     refs(
       refPrefix: "refs/tags/",
-      orderBy: { field: TAG_COMMIT_DATE, direction:DESC },
+      orderBy: { field: TAG_COMMIT_DATE, direction: DESC },
       first: 20,
       query: $match
     ) {

--- a/git-version/src/github/index.ts
+++ b/git-version/src/github/index.ts
@@ -1,0 +1,11 @@
+export {
+  getRepository,
+  getCommit,
+  getInput,
+  setOutput,
+  setFailed,
+} from './core'
+
+export * from './getTagList'
+export * from './compareTag'
+export * from './types'

--- a/git-version/src/github/index.ts
+++ b/git-version/src/github/index.ts
@@ -1,4 +1,5 @@
 export {
+  log,
   getRepository,
   getCommit,
   getInput,

--- a/git-version/src/github/types.ts
+++ b/git-version/src/github/types.ts
@@ -1,0 +1,25 @@
+export type InputName =
+  | 'github-token'
+  | 'tag-prefix'
+  | 'bump'
+  | 'prerelease-id'
+  | 'snapshot-id'
+
+export type OutputName = 'version'
+
+export interface Commit {
+  commit: string
+}
+
+export interface Repository {
+  owner: string
+  repo: string
+}
+
+export interface Tag {
+  tag: string
+}
+
+export interface AncestorTag extends Tag {
+  distance: number
+}

--- a/git-version/src/main.ts
+++ b/git-version/src/main.ts
@@ -1,0 +1,7 @@
+// action entry point
+import { setOutput, setFailed } from './github'
+import { getGitVersion } from './getGitVersion'
+
+getGitVersion()
+  .then((version) => setOutput('version', version))
+  .catch((error: Error) => setFailed(error))

--- a/git-version/src/main.ts
+++ b/git-version/src/main.ts
@@ -1,7 +1,10 @@
 // action entry point
-import { setOutput, setFailed } from './github'
+import { log, setOutput, setFailed } from './github'
 import { getGitVersion } from './getGitVersion'
 
 getGitVersion()
-  .then((version) => setOutput('version', version))
+  .then((version) => {
+    log.info(`Generated version: ${version}`)
+    setOutput('version', version)
+  })
   .catch((error: Error) => setFailed(error))

--- a/git-version/src/versioning/__tests__/buildVersionString.test.ts
+++ b/git-version/src/versioning/__tests__/buildVersionString.test.ts
@@ -1,0 +1,154 @@
+import { SemVer } from 'semver'
+import { buildVersionString } from '../buildVersionString'
+
+describe('build version string', () => {
+  it('should default to an obvious version if no ancestor', () => {
+    const ancestor = null
+    const commit = { commit: 'abc1234' }
+    const bump = 'preminor'
+    const prereleaseId = 'alpha'
+    const snapshotId = 'dev'
+
+    const result = buildVersionString({
+      ancestor,
+      commit,
+      bump,
+      prereleaseId,
+      snapshotId,
+    })
+
+    expect(result).toEqual('0.0.0-dev+abc1234')
+  })
+
+  it('should return the tag exactly if distance to commit is 0', () => {
+    const ancestor = {
+      tag: 'v1.2.3',
+      distance: 0,
+      semver: new SemVer('v1.2.3'),
+    }
+    const commit = { commit: 'abc1234' }
+    const bump = 'preminor'
+    const prereleaseId = 'alpha'
+    const snapshotId = 'dev'
+
+    const result = buildVersionString({
+      ancestor,
+      commit,
+      bump,
+      prereleaseId,
+      snapshotId,
+    })
+
+    expect(result).toEqual('1.2.3')
+  })
+
+  it('should increment to prerelease and add build number and commit hash', () => {
+    const ancestor = {
+      tag: 'v1.2.3',
+      distance: 2,
+      semver: new SemVer('v1.2.3'),
+    }
+    const commit = { commit: 'abc1234' }
+    const bump = 'preminor'
+    const prereleaseId = 'alpha'
+    const snapshotId = 'dev'
+
+    const result = buildVersionString({
+      ancestor,
+      commit,
+      bump,
+      prereleaseId,
+      snapshotId,
+    })
+
+    expect(result).toEqual('1.3.0-alpha.0.dev.2+abc1234')
+  })
+
+  it('should preserve an existing prerelease for "pre*" bumps', () => {
+    const ancestor = {
+      tag: 'v1.2.3-alpha.42',
+      distance: 2,
+      semver: new SemVer('v1.2.3-alpha.42', { includePrerelease: true }),
+    }
+    const commit = { commit: 'abc1234' }
+    const bump = 'preminor'
+    const prereleaseId = 'alpha'
+    const snapshotId = 'dev'
+
+    const result = buildVersionString({
+      ancestor,
+      commit,
+      bump,
+      prereleaseId,
+      snapshotId,
+    })
+
+    expect(result).toEqual('1.2.3-alpha.43.dev.2+abc1234')
+  })
+
+  it('should swap out the prerelease identifier for "pre*" bumps', () => {
+    const ancestor = {
+      tag: 'v1.2.3-alpha.42',
+      distance: 2,
+      semver: new SemVer('v1.2.3-alpha.42', { includePrerelease: true }),
+    }
+    const commit = { commit: 'abc1234' }
+    const bump = 'preminor'
+    const prereleaseId = 'beta'
+    const snapshotId = 'dev'
+
+    const result = buildVersionString({
+      ancestor,
+      commit,
+      bump,
+      prereleaseId,
+      snapshotId,
+    })
+
+    expect(result).toEqual('1.2.3-beta.0.dev.2+abc1234')
+  })
+
+  it('should increment to a regular release', () => {
+    const ancestor = {
+      tag: 'v1.2.3',
+      distance: 2,
+      semver: new SemVer('v1.2.3'),
+    }
+    const commit = { commit: 'abc1234' }
+    const bump = 'minor'
+    const prereleaseId = 'alpha'
+    const snapshotId = 'dev'
+
+    const result = buildVersionString({
+      ancestor,
+      commit,
+      bump,
+      prereleaseId,
+      snapshotId,
+    })
+
+    expect(result).toEqual('1.3.0-dev.2+abc1234')
+  })
+
+  it('should preserve an existing prerelease for regular releases', () => {
+    const ancestor = {
+      tag: 'v1.2.3-alpha.42',
+      distance: 2,
+      semver: new SemVer('v1.2.3-alpha.42', { includePrerelease: true }),
+    }
+    const commit = { commit: 'abc1234' }
+    const bump = 'minor'
+    const prereleaseId = 'alpha'
+    const snapshotId = 'dev'
+
+    const result = buildVersionString({
+      ancestor,
+      commit,
+      bump,
+      prereleaseId,
+      snapshotId,
+    })
+
+    expect(result).toEqual('1.2.3-alpha.43.dev.2+abc1234')
+  })
+})

--- a/git-version/src/versioning/__tests__/findAncestorTag.test.ts
+++ b/git-version/src/versioning/__tests__/findAncestorTag.test.ts
@@ -1,0 +1,107 @@
+import { SemVer } from 'semver'
+import { when } from 'jest-when'
+
+import { Commit, Repository, Tag, AncestorTag, compareTag } from '../../github'
+import { parseTag } from '../parseTag'
+import { findAncestorTag } from '../findAncestorTag'
+
+jest.mock('../../github')
+jest.mock('../parseTag')
+
+const REPOSITORY: Repository = {
+  owner: 'owner-name',
+  repo: 'repo-name',
+}
+
+const COMMIT: Commit = {
+  commit: 'abc123',
+}
+
+const TAG_LIST: Tag[] = [
+  { tag: 'v7.8.9' },
+  { tag: 'v4.5.6' },
+  { tag: 'v1.2.3' },
+]
+
+const ANCESTOR_123: AncestorTag = {
+  tag: 'v1.2.3',
+  distance: 2,
+}
+
+const ANCESTOR_456: AncestorTag = {
+  tag: 'v4.5.6',
+  distance: 4,
+}
+
+describe('find ancestor tag', () => {
+  beforeEach(() => {
+    when(parseTag)
+      .calledWith({ tagPrefix: 'v', tag: TAG_LIST[0] })
+      .mockReturnValue(new SemVer('v1.2.3'))
+
+    when(parseTag)
+      .calledWith({ tagPrefix: 'v', tag: TAG_LIST[1] })
+      .mockReturnValue(new SemVer('v4.5.6'))
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should compare tags until it finds a match', async () => {
+    when(compareTag)
+      .calledWith({ tag: TAG_LIST[0], repository: REPOSITORY, commit: COMMIT })
+      .mockResolvedValue(null)
+
+    when(compareTag)
+      .calledWith({ tag: TAG_LIST[1], repository: REPOSITORY, commit: COMMIT })
+      .mockResolvedValue(ANCESTOR_456)
+
+    const ancestor = await findAncestorTag({
+      tagPrefix: 'v',
+      tags: TAG_LIST,
+      repository: REPOSITORY,
+      commit: COMMIT,
+    })
+
+    expect(ancestor).toEqual({ ...ANCESTOR_456, semver: new SemVer('v4.5.6') })
+  })
+
+  it('should return the first match that parses', async () => {
+    when(compareTag)
+      .calledWith({ tag: TAG_LIST[0], repository: REPOSITORY, commit: COMMIT })
+      .mockResolvedValue(ANCESTOR_123)
+
+    when(compareTag)
+      .calledWith({ tag: TAG_LIST[1], repository: REPOSITORY, commit: COMMIT })
+      .mockResolvedValue(ANCESTOR_456)
+
+    when(parseTag)
+      .calledWith({ tagPrefix: 'v', tag: TAG_LIST[0] })
+      .mockReturnValue(null)
+
+    const ancestor = await findAncestorTag({
+      tagPrefix: 'v',
+      tags: TAG_LIST,
+      repository: REPOSITORY,
+      commit: COMMIT,
+    })
+
+    expect(ancestor).toEqual({ ...ANCESTOR_456, semver: new SemVer('v4.5.6') })
+  })
+
+  it('should return null if it does not find a match', async () => {
+    when(compareTag)
+      .calledWith(expect.objectContaining({}))
+      .mockResolvedValue(null)
+
+    const ancestor = await findAncestorTag({
+      tagPrefix: 'v',
+      tags: TAG_LIST,
+      repository: REPOSITORY,
+      commit: COMMIT,
+    })
+
+    expect(ancestor).toEqual(null)
+  })
+})

--- a/git-version/src/versioning/__tests__/parseTag.test.ts
+++ b/git-version/src/versioning/__tests__/parseTag.test.ts
@@ -1,0 +1,22 @@
+import { SemVer } from 'semver'
+import { parseTag } from '../parseTag'
+
+describe('parse tag', () => {
+  it('should return null if tag prefix does not match', () => {
+    const tagPrefix = 'foobar'
+    const tag = { tag: 'v1.2.3' }
+
+    const result = parseTag({ tag, tagPrefix })
+
+    expect(result).toBe(null)
+  })
+
+  it('should parse out a SemVer', () => {
+    const tagPrefix = 'v'
+    const tag = { tag: 'v1.2.3' }
+
+    const result = parseTag({ tag, tagPrefix })
+
+    expect(result).toEqual(new SemVer('v1.2.3', { includePrerelease: true }))
+  })
+})

--- a/git-version/src/versioning/buildVersionString.ts
+++ b/git-version/src/versioning/buildVersionString.ts
@@ -1,0 +1,35 @@
+import incrementSemver from 'semver/functions/inc'
+import { Commit } from '../github'
+import { ParsedAncestorTag, Bump } from './types'
+
+export interface BuildVersionOptions {
+  ancestor: ParsedAncestorTag | null
+  commit: Commit
+  bump: Bump
+  prereleaseId: string
+  snapshotId: string
+}
+
+export function buildVersionString(options: BuildVersionOptions): string {
+  const { ancestor, commit, prereleaseId, snapshotId } = options
+  const shortSha = commit.commit.slice(0, 7)
+
+  if (ancestor === null) {
+    return `0.0.0-${snapshotId}+${shortSha}`
+  }
+
+  if (ancestor.distance === 0) {
+    return ancestor.semver.version
+  }
+
+  const { semver, distance } = ancestor
+  const prevIsPrerelease = semver.prerelease.length > 0
+  const bump = prevIsPrerelease ? 'prerelease' : options.bump
+  const nextIsPrerelease = bump.startsWith('pre')
+
+  const nextVersion = incrementSemver(semver, bump, prereleaseId) as string
+  const dotOrDash = nextIsPrerelease ? '.' : '-'
+  const snapshotPostfix = `${snapshotId}.${distance}+${shortSha}`
+
+  return `${nextVersion}${dotOrDash}${snapshotPostfix}`
+}

--- a/git-version/src/versioning/findAncestorTag.ts
+++ b/git-version/src/versioning/findAncestorTag.ts
@@ -1,0 +1,36 @@
+import { Commit, Repository, Tag, compareTag } from '../github'
+import { parseTag } from './parseTag'
+import { ParsedAncestorTag } from './types'
+
+export interface FindAncestorOptions {
+  tagPrefix: string
+  tags: Tag[]
+  commit: Commit
+  repository: Repository
+}
+
+export function findAncestorTag(
+  options: FindAncestorOptions
+): Promise<ParsedAncestorTag | null> {
+  const { tagPrefix, tags, commit, repository } = options
+  const tagQueue = [...tags]
+  const tag = tagQueue.shift()
+
+  if (tag == null) {
+    return Promise.resolve(null)
+  }
+
+  const semver = parseTag({ tagPrefix, tag })
+
+  if (semver === null) {
+    return findAncestorTag({ ...options, tags: tagQueue })
+  }
+
+  return compareTag({ tag, commit, repository }).then((result) => {
+    if (result == null) {
+      return findAncestorTag({ ...options, tags: tagQueue })
+    }
+
+    return { ...result, semver }
+  })
+}

--- a/git-version/src/versioning/findAncestorTag.ts
+++ b/git-version/src/versioning/findAncestorTag.ts
@@ -17,7 +17,6 @@ export function findAncestorTag(
   const tag = tagQueue.shift()
 
   if (tag == null) {
-    log.warning('Unable to find a valid version tag')
     return Promise.resolve(null)
   }
 
@@ -25,7 +24,7 @@ export function findAncestorTag(
 
   if (semver === null) {
     log.warning(
-      `Tag ${tag.tag} did not start with ${tagPrefix} or could not be parsed as SemVer. Continuing search.`
+      `Tag ${tag.tag} did not match ${tagPrefix} or could not be parsed. Continuing search.`
     )
     return findAncestorTag({ ...options, tags: tagQueue })
   }

--- a/git-version/src/versioning/findAncestorTag.ts
+++ b/git-version/src/versioning/findAncestorTag.ts
@@ -1,4 +1,4 @@
-import { Commit, Repository, Tag, compareTag } from '../github'
+import { Commit, Repository, Tag, compareTag, log } from '../github'
 import { parseTag } from './parseTag'
 import { ParsedAncestorTag } from './types'
 
@@ -17,12 +17,16 @@ export function findAncestorTag(
   const tag = tagQueue.shift()
 
   if (tag == null) {
+    log.warning('Unable to find a valid version tag')
     return Promise.resolve(null)
   }
 
   const semver = parseTag({ tagPrefix, tag })
 
   if (semver === null) {
+    log.warning(
+      `Tag ${tag.tag} did not start with ${tagPrefix} or could not be parsed as SemVer. Continuing search.`
+    )
     return findAncestorTag({ ...options, tags: tagQueue })
   }
 

--- a/git-version/src/versioning/index.ts
+++ b/git-version/src/versioning/index.ts
@@ -1,0 +1,3 @@
+export * from './findAncestorTag'
+export * from './buildVersionString'
+export * from './types'

--- a/git-version/src/versioning/parseTag.ts
+++ b/git-version/src/versioning/parseTag.ts
@@ -1,0 +1,20 @@
+import parseSemver from 'semver/functions/parse'
+
+import { Tag } from '../github'
+import { SemVer } from './types'
+
+export interface ParseTagOptions {
+  tag: Tag
+  tagPrefix: string
+}
+
+export function parseTag(options: ParseTagOptions): SemVer | null {
+  const { tag, tagPrefix } = options
+  const semver = parseSemver(tag.tag, { includePrerelease: true })
+
+  if (!tag.tag.startsWith(tagPrefix) || semver === null) {
+    return null
+  }
+
+  return semver
+}

--- a/git-version/src/versioning/types.ts
+++ b/git-version/src/versioning/types.ts
@@ -1,0 +1,8 @@
+import type { SemVer, ReleaseType as Bump } from 'semver'
+import type { AncestorTag } from '../github'
+
+export interface ParsedAncestorTag extends AncestorTag {
+  semver: SemVer
+}
+
+export type { Bump, SemVer }

--- a/git-version/tsconfig.json
+++ b/git-version/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig-base.json",
+  "references": [],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src", "../typings"]
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -39,6 +39,6 @@ const createConfig = (options) => ({
   ...plugins(options),
 })
 
-const packages = []
+const packages = [{ packageName: 'git-version' }]
 
 export default packages.map(createConfig)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "files": [],
-  "references": []
+  "references": [
+    {
+      "path": "./git-version"
+    }
+  ]
 }


### PR DESCRIPTION
## overview

This PR adds a custom GitHub Action to use git metadata to generate snapshot version strings using a `git describe`-like algorithm. Closes #1. See ticket for background and acceptance criteria. Based off of prior work in Opentrons/opentrons#6669.

Inputs into the action:

| name            | default | required | description                             | example                       |
| --------------- | ------- | -------- | --------------------------------------- | ----------------------------- |
| `github-token`  | N/A     | **yes**  | GitHub access token                     | `${{ secrets.GITHUB_TOKEN }}` |
| `tag-prefix`    | `v`     | no       | Prefix to filter tags                   | `v`, `project-name@`          |
| `bump`          | `minor` | no       | Bump to create snapshot version         | `prerelease`, `patch`         |
| `snapshot-id`   | `dev`   | no       | Label to mark snapshot version          | `dev`, `SNAPSHOT`             |
| `prerelease-id` | `alpha` | no       | If `bump` is a prerelease, label to use | `alpha`, `canary`    

Outputs from the action:

| name      | description                      | example                       |
| --------- | -------------------------------- | ----------------------------- |
| `version` | Calculated version for the build | `1.3.0-dev.10+abc1234`   |

Example outputs:

| bump       | prerelease ID | snapshot ID | closest tag      | commits ahead | current SHA | output                         |
| ---------- | ------------- | ----------- | ---------------- | ------------- | ----------- | ------------------------------ |
| `minor`    | `alpha`       | `dev`       | `v1.2.3`         | 0             | `abc1234`   | `1.2.3`                        |
| `minor`    | `alpha`       | `dev`       | None found       | N/A           | `abc1234`   | `0.0.0-dev+abc1234`            |
| `minor`    | `alpha`       | `dev`       | `v1.2.3`         | 10            | `abc1234`   | `1.3.0-dev.10+abc1234`         |
| `preminor` | `alpha`       | `dev`       | `v1.2.3`         | 10            | `abc1234`   | `1.3.0-alpha.0.dev.10+abc1234` |
| `preminor` | `alpha`       | `dev`       | `v1.2.3`         | 10            | `abc1234`   | `1.3.0-alpha.0.dev.10+abc1234` |
| `preminor` | `alpha`       | `dev`       | `v1.2.3-alpha.3` | 10            | `abc1234`   | `1.2.3-alpha.4.dev.10+abc1234` |
| `minor`    | `alpha`       | `dev`       | `v1.2.3-alpha.3` | 10            | `abc1234`   | `1.2.3-alpha.4.dev.10+abc1234` |
| `preminor` | `beta`        | `dev`       | `v1.2.3-alpha.3` | 10            | `abc1234`   | `1.2.3-beta.0.dev.10+abc1234`  |

## testing

I tested this out over in [a Opentrons/junk-drawer workflow](https://github.com/Opentrons/junk-drawer/runs/2267239038?check_suite_focus=true); look for the "Calculate Version" step in the "Build assets and deploy on tags" job.

Given Opentrons/software-factory-scripts#71, I'll probably be trying something out over there, too. We can test this out in any workflow with:

```yaml
# ...
steps:
  # ...
  - name: 'Calculate version string from git'
    id: version
    uses: Opentrons/actions/git-version@git-version
    with:
      github-token: ${{ secrets.GITHUB_TOKEN }}

  - name: 'Print version'
    run: echo "Version: ${{ steps.version.outputs.version }}"
# ...
```

## todo (future PR)

We gotta figure out a coherent release strategy for these things given that there's a required bundling step. A potential idea is to have a workflow that listens for pushes to `main`, and when `main` gets updated, it can bundle the actions, commit, and push them.